### PR TITLE
fix failed unit-tests

### DIFF
--- a/gaussdbconn/config.go
+++ b/gaussdbconn/config.go
@@ -290,6 +290,11 @@ func ParseConfigWithOptions(connString string, options ParseConfigOptions) (*Con
 			if strings.EqualFold(gaussdbError.Severity, "FATAL") {
 				return false
 			}
+			// in gaussdb when 'Invalid username/password,login denied.', it's ERROR severity not FATAL.
+			// related test case: TestConnectInvalidUser
+			if strings.EqualFold(gaussdbError.Severity, "ERROR") && gaussdbError.Code == "28P01" {
+				return false
+			}
 			return true
 		},
 	}

--- a/gaussdbproto/authentication_sha256.go
+++ b/gaussdbproto/authentication_sha256.go
@@ -20,10 +20,10 @@ type AuthenticationSHA256 struct {
 // Backend identifies this message as sendable by the GaussDB backend.
 func (*AuthenticationSHA256) Backend() {}
 
-// Backend identifies this message as an authentication response.
+// AuthenticationResponse identifies this message as an authentication response.
 func (*AuthenticationSHA256) AuthenticationResponse() {}
 
-// Decode decodes src into dst. src must contain the complete message with the exception of the initial 1 byte message
+// Decode decodes src into dst. src must contain the complete message except the initial 1 byte message
 // type identifier and 4 byte message length.
 func (dst *AuthenticationSHA256) Decode(src []byte) error {
 	if len(src) < 4 {
@@ -39,6 +39,9 @@ func (dst *AuthenticationSHA256) Decode(src []byte) error {
 	readBuf := ReadBuf(src)
 	dst.r = &readBuf
 
+	if len(src) < 82 {
+		return &invalidMessageFormatErr{messageType: "AuthenticationSASL", details: "at least 82 bytes"}
+	}
 	authMechanisms := src[8:82]
 	for len(authMechanisms) > 1 {
 		idx := bytes.IndexByte(authMechanisms, 0)

--- a/gaussdbproto/json_test.go
+++ b/gaussdbproto/json_test.go
@@ -518,9 +518,9 @@ func TestJSONUnmarshalSASLResponse(t *testing.T) {
 }
 
 func TestJSONUnmarshalStartupMessage(t *testing.T) {
-	data := []byte(`{"Type":"StartupMessage","ProtocolVersion":196608,"Parameters":{"database":"testing","user":"postgres"}}`)
+	data := []byte(`{"Type":"StartupMessage","ProtocolVersion":196659,"Parameters":{"database":"testing","user":"postgres"}}`)
 	want := StartupMessage{
-		ProtocolVersion: 196608,
+		ProtocolVersion: 196659,
 		Parameters: map[string]string{
 			"database": "testing",
 			"user":     "postgres",

--- a/gaussdbtype/date_test.go
+++ b/gaussdbtype/date_test.go
@@ -52,8 +52,7 @@ func TestDateCodecTextEncode(t *testing.T) {
 		{source: gaussdbtype.Date{Time: time.Date(789, 1, 2, 0, 0, 0, 0, time.UTC), Valid: true}, result: "0789-01-02"},
 		{source: gaussdbtype.Date{Time: time.Date(89, 1, 2, 0, 0, 0, 0, time.UTC), Valid: true}, result: "0089-01-02"},
 		{source: gaussdbtype.Date{Time: time.Date(9, 1, 2, 0, 0, 0, 0, time.UTC), Valid: true}, result: "0009-01-02"},
-		// todo: simple protocol: ERROR: invalid data for "year =  12200", value must be between -4712 and 9999, and not be 0 (SQLSTATE 22020)
-		//{source: gaussdbtype.Date{Time: time.Date(12200, 1, 2, 0, 0, 0, 0, time.UTC), Valid: true}, result: "12200-01-02"},
+		{source: gaussdbtype.Date{Time: time.Date(12200, 1, 2, 0, 0, 0, 0, time.UTC), Valid: true}, result: "12200-01-02"},
 		{source: gaussdbtype.Date{Time: time.Date(9999, 1, 2, 0, 0, 0, 0, time.UTC), Valid: true}, result: "9999-01-02"},
 		{source: gaussdbtype.Date{InfinityModifier: gaussdbtype.Infinity, Valid: true}, result: "infinity"},
 		{source: gaussdbtype.Date{InfinityModifier: gaussdbtype.NegativeInfinity, Valid: true}, result: "-infinity"},

--- a/gaussdbtype/xml_test.go
+++ b/gaussdbtype/xml_test.go
@@ -84,45 +84,43 @@ func TestXMLCodecUnmarshalSQLNull(t *testing.T) {
 func TestXMLCodecPointerToPointerToString(t *testing.T) {
 	defaultConnTestRunner.RunTest(context.Background(), t, func(ctx context.Context, t testing.TB, conn *gaussdbx.Conn) {
 		var s *string
-		err := conn.QueryRow(ctx, "select ''::xml").Scan(&s)
-		require.NoError(t, err)
-		//todo: gaussdb return nil
-		require.Nil(t, s)
+		// todo: gaussdb not support "select ''::xml", complaints: invalid XML content (SQLSTATE 2200N)
+		//err := conn.QueryRow(ctx, "select ''::xml").Scan(&s)
+		//require.NoError(t, err)
+		//require.Nil(t, s)
 		//require.NotNil(t, s)
 		//require.Equal(t, "", *s)
 
-		err = conn.QueryRow(ctx, "select null::xml").Scan(&s)
+		err := conn.QueryRow(ctx, "select null::xml").Scan(&s)
 		require.NoError(t, err)
 		require.Nil(t, s)
 	})
 }
 
-// todo: in opengauss it complaints: "This functionality requires the server to be built with libxml support", but gaussdb support it.
-//func TestXMLCodecDecodeValue(t *testing.T) {
-//	skipCockroachDB(t, "CockroachDB does not support XML.")
-//	defaultConnTestRunner.RunTest(context.Background(), t, func(ctx context.Context, _ testing.TB, conn *gaussdbx.Conn) {
-//		for _, tt := range []struct {
-//			sql      string
-//			expected any
-//		}{
-//			{
-//				sql:      `select '<foo>bar</foo>'::xml`,
-//				expected: []byte("<foo>bar</foo>"),
-//			},
-//		} {
-//			t.Run(tt.sql, func(t *testing.T) {
-//				rows, err := conn.Query(ctx, tt.sql)
-//				require.NoError(t, err)
-//
-//				for rows.Next() {
-//					values, err := rows.Values()
-//					require.NoError(t, err)
-//					require.Len(t, values, 1)
-//					require.Equal(t, tt.expected, values[0])
-//				}
-//
-//				require.NoError(t, rows.Err())
-//			})
-//		}
-//	})
-//}
+func TestXMLCodecDecodeValue(t *testing.T) {
+	defaultConnTestRunner.RunTest(context.Background(), t, func(ctx context.Context, _ testing.TB, conn *gaussdbx.Conn) {
+		for _, tt := range []struct {
+			sql      string
+			expected any
+		}{
+			{
+				sql:      `select '<foo>bar</foo>'::xml`,
+				expected: []byte("<foo>bar</foo>"),
+			},
+		} {
+			t.Run(tt.sql, func(t *testing.T) {
+				rows, err := conn.Query(ctx, tt.sql)
+				require.NoError(t, err)
+
+				for rows.Next() {
+					values, err := rows.Values()
+					require.NoError(t, err)
+					require.Len(t, values, 1)
+					require.Equal(t, tt.expected, values[0])
+				}
+
+				require.NoError(t, rows.Err())
+			})
+		}
+	})
+}

--- a/testsetup/postgresql_setup.sql
+++ b/testsetup/postgresql_setup.sql
@@ -1,8 +1,7 @@
 -- Create extensions and types.
 create extension if not exists hstore;
 
--- Create database pgx_test
---create database pgx_test;
+create database pgx_test DBCOMPATIBILITY 'pg';
 
 -- Create users for different types of connections and authentication.
 create user pgx_ssl with SYSADMIN PASSWORD 'Gaussdb@123!';


### PR DESCRIPTION
fix some failed unit tests:
- TestFatalTxError
- TestFatalRxError
- TestConnCopyFromNoticeResponseReceivedMidStream
- TestConnectInvalidUser
- TestConnectTLSPasswordProtectedClientCertWithGetSSLPasswordConfigOption
- TestConnectTLSPasswordProtectedClientCertWithSSLPassword
- TestConnectTLS
- TestConnCopyToSmall
- TestConnOnNotification
- TestConnWaitForNotification
- TestConnOnNotice
- TestConnCopyToLarge
- TestConnCheckConn
- FuzzFrontend
- TestBitsCodecVarbit
- TestDateCodec