### PR TITLE
compatible opengauss and gauss error info

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,15 +89,15 @@ jobs:
       #     ## limits ssh access and adds the ssh public key for the user which triggered the workflow
       #     limit-access-to-actor: true
       #   env:
-      #     PGX_TEST_DATABASE: ${{ matrix.pgx-test-database }}
-      #     PGX_TEST_UNIX_SOCKET_CONN_STRING: ${{ matrix.pgx-test-unix-socket-conn-string }}
-      #     PGX_TEST_TCP_CONN_STRING: ${{ matrix.pgx-test-tcp-conn-string }}
-      #     PGX_TEST_SCRAM_PASSWORD_CONN_STRING: ${{ matrix.pgx-test-scram-password-conn-string }}
-      #     PGX_TEST_MD5_PASSWORD_CONN_STRING: ${{ matrix.pgx-test-md5-password-conn-string }}
-      #     PGX_TEST_PLAIN_PASSWORD_CONN_STRING: ${{ matrix.pgx-test-plain-password-conn-string }}
-      #     PGX_TEST_TLS_CONN_STRING: ${{ matrix.pgx-test-tls-conn-string }}
-      #     PGX_SSL_PASSWORD: ${{ matrix.pgx-ssl-password }}
-      #     PGX_TEST_TLS_CLIENT_CONN_STRING: ${{ matrix.pgx-test-tls-client-conn-string }}
+      #     GAUSSDB_TEST_DATABASE: ${{ matrix.pgx-test-database }}
+      #     GAUSSDB_TEST_UNIX_SOCKET_CONN_STRING: ${{ matrix.pgx-test-unix-socket-conn-string }}
+      #     GAUSSDB_TEST_TCP_CONN_STRING: ${{ matrix.pgx-test-tcp-conn-string }}
+      #     GAUSSDB_TEST_SCRAM_PASSWORD_CONN_STRING: ${{ matrix.pgx-test-scram-password-conn-string }}
+      #     GAUSSDB_TEST_MD5_PASSWORD_CONN_STRING: ${{ matrix.pgx-test-md5-password-conn-string }}
+      #     GAUSSDB_TEST_PLAIN_PASSWORD_CONN_STRING: ${{ matrix.pgx-test-plain-password-conn-string }}
+      #     GAUSSDB_TEST_TLS_CONN_STRING: ${{ matrix.pgx-test-tls-conn-string }}
+      #     GAUSSDB_SSL_PASSWORD: ${{ matrix.pgx-ssl-password }}
+      #     GAUSSDB_TEST_TLS_CLIENT_CONN_STRING: ${{ matrix.pgx-test-tls-client-conn-string }}
 
       - name: Check formatting
         run: |
@@ -109,16 +109,16 @@ jobs:
         # parallel testing is disabled because somehow parallel testing causes Github Actions to kill the runner.
         run: go test -parallel=1 -race ./...
         env:
-          PGX_TEST_DATABASE: ${{ matrix.pgx-test-database }}
-          PGX_TEST_UNIX_SOCKET_CONN_STRING: ${{ matrix.pgx-test-unix-socket-conn-string }}
-          PGX_TEST_TCP_CONN_STRING: ${{ matrix.pgx-test-tcp-conn-string }}
-          PGX_TEST_SCRAM_PASSWORD_CONN_STRING: ${{ matrix.pgx-test-scram-password-conn-string }}
-          PGX_TEST_MD5_PASSWORD_CONN_STRING: ${{ matrix.pgx-test-md5-password-conn-string }}
-          PGX_TEST_PLAIN_PASSWORD_CONN_STRING: ${{ matrix.pgx-test-plain-password-conn-string }}
+          GAUSSDB_TEST_DATABASE: ${{ matrix.pgx-test-database }}
+          GAUSSDB_TEST_UNIX_SOCKET_CONN_STRING: ${{ matrix.pgx-test-unix-socket-conn-string }}
+          GAUSSDB_TEST_TCP_CONN_STRING: ${{ matrix.pgx-test-tcp-conn-string }}
+          GAUSSDB_TEST_SCRAM_PASSWORD_CONN_STRING: ${{ matrix.pgx-test-scram-password-conn-string }}
+          GAUSSDB_TEST_MD5_PASSWORD_CONN_STRING: ${{ matrix.pgx-test-md5-password-conn-string }}
+          GAUSSDB_TEST_PLAIN_PASSWORD_CONN_STRING: ${{ matrix.pgx-test-plain-password-conn-string }}
           # TestConnectTLS fails. However, it succeeds if I connect to the CI server with upterm and run it. Give up on that test for now.
-          # PGX_TEST_TLS_CONN_STRING: ${{ matrix.pgx-test-tls-conn-string }}
-          PGX_SSL_PASSWORD: ${{ matrix.pgx-ssl-password }}
-          PGX_TEST_TLS_CLIENT_CONN_STRING: ${{ matrix.pgx-test-tls-client-conn-string }}
+          # GAUSSDB_TEST_TLS_CONN_STRING: ${{ matrix.pgx-test-tls-conn-string }}
+          GAUSSDB_SSL_PASSWORD: ${{ matrix.pgx-ssl-password }}
+          GAUSSDB_TEST_TLS_CLIENT_CONN_STRING: ${{ matrix.pgx-test-tls-client-conn-string }}
 
   test-windows:
     name: Test Windows
@@ -153,4 +153,4 @@ jobs:
         # parallel testing is disabled because somehow parallel testing causes Github Actions to kill the runner.
         run: go test -parallel=1 -race  ./...
         env:
-          PGX_TEST_DATABASE: ${{ steps.postgres.outputs.connection-uri }}
+          GAUSSDB_TEST_DATABASE: ${{ steps.postgres.outputs.connection-uri }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,8 @@ that adds a dependency is no.
 
 ## Development Environment Setup
 
-gaussdb-go tests naturally require a GaussDB database. It will connect to the database specified in the `PGX_TEST_DATABASE`
-environment variable. The `PGX_TEST_DATABASE` environment variable can either be a URL or key-value pairs. In addition,
+gaussdb-go tests naturally require a GaussDB database. It will connect to the database specified in the `GAUSSDB_TEST_DATABASE`
+environment variable. The `GAUSSDB_TEST_DATABASE` environment variable can either be a URL or key-value pairs. In addition,
 the standard `PG*` environment variables will be respected. Consider using [direnv](https://github.com/direnv/direnv) to
 simplify environment variable handling.
 
@@ -30,10 +30,10 @@ gsql -c 'create database pgx_test DBCOMPATIBILITY 'PG'; create extension hstore;
 ```
 
 ```
-Ensure your `PGX_TEST_DATABASE` environment variable points to the database you just created and run the tests.
+Ensure your `GAUSSDB_TEST_DATABASE` environment variable points to the database you just created and run the tests.
 
 ```
-export PGX_TEST_DATABASE="host='your gaussdb host' database=pgx_test"
+export GAUSSDB_TEST_DATABASE="host='your gaussdb host' database=pgx_test"
 go test ./...
 ```
 
@@ -42,7 +42,7 @@ This will run the vast majority of the tests, but some tests will be skipped (e.
 ### Creating a New GaussDB Cluster Exclusively for Testing
 
 The following environment variables need to be set both for initial setup and whenever the tests are run. (direnv is
-highly recommended). Depending on your platform, you may need to change the host for `PGX_TEST_UNIX_SOCKET_CONN_STRING`.
+highly recommended). Depending on your platform, you may need to change the host for `GAUSSDB_TEST_UNIX_SOCKET_CONN_STRING`.
 
 ```
 export PGPORT=5015
@@ -50,15 +50,15 @@ export PGUSER=root
 export PGDATABASE=pgx_test
 export POSTGRESQL_DATA_DIR=GaussDB
 
-export PGX_TEST_DATABASE="host=127.0.0.1 database=pgx_test user=pgx_md5 password=secret"
-export PGX_TEST_UNIX_SOCKET_CONN_STRING="host=/private/tmp database=pgx_test"
-export PGX_TEST_TCP_CONN_STRING="host=127.0.0.1 database=pgx_test user=pgx_md5 password=secret"
-export PGX_TEST_SCRAM_PASSWORD_CONN_STRING="host=127.0.0.1 user=pgx_scram password=secret database=pgx_test"
-export PGX_TEST_MD5_PASSWORD_CONN_STRING="host=127.0.0.1 database=pgx_test user=pgx_md5 password=secret"
-export PGX_TEST_PLAIN_PASSWORD_CONN_STRING="host=127.0.0.1 user=pgx_pw password=secret"
-export PGX_TEST_TLS_CONN_STRING="host=localhost user=pgx_ssl password=secret sslmode=verify-full sslrootcert=`pwd`/.testdb/ca.pem"
-export PGX_SSL_PASSWORD=certpw
-export PGX_TEST_TLS_CLIENT_CONN_STRING="host=localhost user=pgx_sslcert sslmode=verify-full sslrootcert=`pwd`/.testdb/ca.pem database=pgx_test sslcert=`pwd`/.testdb/pgx_sslcert.crt sslkey=`pwd`/.testdb/pgx_sslcert.key"
+export GAUSSDB_TEST_DATABASE="host=127.0.0.1 database=pgx_test user=pgx_md5 password=secret"
+export GAUSSDB_TEST_UNIX_SOCKET_CONN_STRING="host=/private/tmp database=pgx_test"
+export GAUSSDB_TEST_TCP_CONN_STRING="host=127.0.0.1 database=pgx_test user=pgx_md5 password=secret"
+export GAUSSDB_TEST_SCRAM_PASSWORD_CONN_STRING="host=127.0.0.1 user=pgx_scram password=secret database=pgx_test"
+export GAUSSDB_TEST_MD5_PASSWORD_CONN_STRING="host=127.0.0.1 database=pgx_test user=pgx_md5 password=secret"
+export GAUSSDB_TEST_PLAIN_PASSWORD_CONN_STRING="host=127.0.0.1 user=pgx_pw password=secret"
+export GAUSSDB_TEST_TLS_CONN_STRING="host=localhost user=pgx_ssl password=secret sslmode=verify-full sslrootcert=`pwd`/.testdb/ca.pem"
+export GAUSSDB_SSL_PASSWORD=certpw
+export GAUSSDB_TEST_TLS_CLIENT_CONN_STRING="host=localhost user=pgx_sslcert sslmode=verify-full sslrootcert=`pwd`/.testdb/ca.pem database=pgx_test sslcert=`pwd`/.testdb/pgx_sslcert.crt sslkey=`pwd`/.testdb/pgx_sslcert.key"
 ```
 
 Create a new database cluster.

--- a/batch_test.go
+++ b/batch_test.go
@@ -1019,9 +1019,8 @@ func TestConnSendBatchErrorDoesNotLeaveOrphanedPreparedStatement(t *testing.T) {
 		batch.Queue("select col1 from foo")
 		batch.Queue("select col1 from baz")
 		err := conn.SendBatch(ctx, batch).Close()
-		// todo: opengauss, gaussdb return different error.
-		//require.EqualError(t, err, `ERROR: relation "baz" does not exist on gaussdb (SQLSTATE 42P01)`)
-		require.Contains(t, err.Error(), `ERROR: Relation "baz" does not exist on`)
+		// opengauss, gaussdb return different error.
+		require.Contains(t, err.Error(), lowerFirstLetterInError(`ERROR: Relation "baz" does not exist on`))
 		var gaussdbConnErr *gaussdbconn.GaussdbError
 
 		ok := errors.As(err, &gaussdbConnErr)

--- a/batch_test.go
+++ b/batch_test.go
@@ -424,7 +424,7 @@ func TestConnSendBatchWithPreparedStatementAndStatementCacheDisabled(t *testing.
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	config, err := gaussdbgo.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	config, err := gaussdbgo.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 
 	config.DefaultQueryExecMode = gaussdbgo.QueryExecModeDescribeExec
@@ -899,7 +899,7 @@ func TestConnSendBatchNoStatementCache(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	config := mustParseConfig(t, os.Getenv("PGX_TEST_DATABASE"))
+	config := mustParseConfig(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	config.DefaultQueryExecMode = gaussdbgo.QueryExecModeDescribeExec
 	config.StatementCacheCapacity = 0
 	config.DescriptionCacheCapacity = 0
@@ -914,7 +914,7 @@ func TestConnSendBatchPrepareStatementCache(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	config := mustParseConfig(t, os.Getenv("PGX_TEST_DATABASE"))
+	config := mustParseConfig(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	config.DefaultQueryExecMode = gaussdbgo.QueryExecModeCacheStatement
 	config.StatementCacheCapacity = 32
 
@@ -928,7 +928,7 @@ func TestConnSendBatchDescribeStatementCache(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	config := mustParseConfig(t, os.Getenv("PGX_TEST_DATABASE"))
+	config := mustParseConfig(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	config.DefaultQueryExecMode = gaussdbgo.QueryExecModeCacheDescribe
 	config.DescriptionCacheCapacity = 32
 
@@ -970,7 +970,7 @@ func TestSendBatchSimpleProtocol(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	config := mustParseConfig(t, os.Getenv("PGX_TEST_DATABASE"))
+	config := mustParseConfig(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	config.DefaultQueryExecMode = gaussdbgo.QueryExecModeSimpleProtocol
 
 	conn := mustConnect(t, config)
@@ -1042,7 +1042,7 @@ func ExampleConn_SendBatch() {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	conn, err := gaussdbgo.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	conn, err := gaussdbgo.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	if err != nil {
 		fmt.Printf("Unable to establish connection: %v", err)
 		return

--- a/bench_test.go
+++ b/bench_test.go
@@ -922,7 +922,7 @@ func getSelectRowsCounts(b *testing.B) []int64 {
 			for _, p := range strings.Split(s, " ") {
 				n, err := strconv.ParseInt(p, 10, 64)
 				if err != nil {
-					b.Fatalf("Bad GAUSSDB_BENCH_SELECT_ROWS_COUNTS value: %v", err)
+					b.Fatalf("Bad %s value: %v", gaussdbgo.EnvGaussdbBenchSelectRowsCounts, err)
 				}
 				rowCounts = append(rowCounts, n)
 			}

--- a/bench_test.go
+++ b/bench_test.go
@@ -20,7 +20,7 @@ import (
 
 func BenchmarkConnectClose(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		conn, err := gaussdbgo.Connect(context.Background(), os.Getenv("PGX_TEST_DATABASE"))
+		conn, err := gaussdbgo.Connect(context.Background(), os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -33,7 +33,7 @@ func BenchmarkConnectClose(b *testing.B) {
 }
 
 func BenchmarkMinimalUnpreparedSelectWithoutStatementCache(b *testing.B) {
-	config := mustParseConfig(b, os.Getenv("PGX_TEST_DATABASE"))
+	config := mustParseConfig(b, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	config.DefaultQueryExecMode = gaussdbgo.QueryExecModeDescribeExec
 	config.StatementCacheCapacity = 0
 	config.DescriptionCacheCapacity = 0
@@ -57,7 +57,7 @@ func BenchmarkMinimalUnpreparedSelectWithoutStatementCache(b *testing.B) {
 }
 
 func BenchmarkMinimalUnpreparedSelectWithStatementCacheModeDescribe(b *testing.B) {
-	config := mustParseConfig(b, os.Getenv("PGX_TEST_DATABASE"))
+	config := mustParseConfig(b, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	config.DefaultQueryExecMode = gaussdbgo.QueryExecModeCacheDescribe
 	config.StatementCacheCapacity = 0
 	config.DescriptionCacheCapacity = 32
@@ -81,7 +81,7 @@ func BenchmarkMinimalUnpreparedSelectWithStatementCacheModeDescribe(b *testing.B
 }
 
 func BenchmarkMinimalUnpreparedSelectWithStatementCacheModePrepare(b *testing.B) {
-	config := mustParseConfig(b, os.Getenv("PGX_TEST_DATABASE"))
+	config := mustParseConfig(b, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	config.DefaultQueryExecMode = gaussdbgo.QueryExecModeCacheStatement
 	config.StatementCacheCapacity = 32
 	config.DescriptionCacheCapacity = 0
@@ -105,7 +105,7 @@ func BenchmarkMinimalUnpreparedSelectWithStatementCacheModePrepare(b *testing.B)
 }
 
 func BenchmarkMinimalPreparedSelect(b *testing.B) {
-	conn := mustConnect(b, mustParseConfig(b, os.Getenv("PGX_TEST_DATABASE")))
+	conn := mustConnect(b, mustParseConfig(b, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase)))
 	defer closeConn(b, conn)
 
 	_, err := conn.Prepare(context.Background(), "ps1", "select $1::int8")
@@ -129,7 +129,7 @@ func BenchmarkMinimalPreparedSelect(b *testing.B) {
 }
 
 func BenchmarkMinimalGaussdbConnPreparedSelect(b *testing.B) {
-	conn := mustConnect(b, mustParseConfig(b, os.Getenv("PGX_TEST_DATABASE")))
+	conn := mustConnect(b, mustParseConfig(b, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase)))
 	defer closeConn(b, conn)
 
 	gaussdbConn := conn.GaussdbConn()
@@ -164,7 +164,7 @@ func BenchmarkMinimalGaussdbConnPreparedSelect(b *testing.B) {
 }
 
 func BenchmarkPointerPointerWithNullValues(b *testing.B) {
-	conn := mustConnect(b, mustParseConfig(b, os.Getenv("PGX_TEST_DATABASE")))
+	conn := mustConnect(b, mustParseConfig(b, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase)))
 	defer closeConn(b, conn)
 
 	_, err := conn.Prepare(context.Background(), "selectNulls", "select 1::int4, 'johnsmith', null::text, null::text, null::text, null::date, null::timestamptz")
@@ -224,7 +224,7 @@ func BenchmarkPointerPointerWithNullValues(b *testing.B) {
 }
 
 func BenchmarkPointerPointerWithPresentValues(b *testing.B) {
-	conn := mustConnect(b, mustParseConfig(b, os.Getenv("PGX_TEST_DATABASE")))
+	conn := mustConnect(b, mustParseConfig(b, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase)))
 	defer closeConn(b, conn)
 
 	_, err := conn.Prepare(context.Background(), "selectNulls", "select 1::int4, 'johnsmith', 'johnsmith@example.com', 'John Smith', 'male', '1970-01-01'::date, '2015-01-01 00:00:00'::timestamptz")
@@ -374,7 +374,7 @@ func newBenchmarkWriteTableCopyFromSrc(count int) gaussdbgo.CopyFromSource {
 }
 
 func benchmarkWriteNRowsViaInsert(b *testing.B, n int) {
-	conn := mustConnect(b, mustParseConfig(b, os.Getenv("PGX_TEST_DATABASE")))
+	conn := mustConnect(b, mustParseConfig(b, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase)))
 	defer closeConn(b, conn)
 
 	mustExec(b, conn, benchmarkWriteTableCreateSQL)
@@ -408,7 +408,7 @@ func benchmarkWriteNRowsViaInsert(b *testing.B, n int) {
 }
 
 func benchmarkWriteNRowsViaBatchInsert(b *testing.B, n int) {
-	conn := mustConnect(b, mustParseConfig(b, os.Getenv("PGX_TEST_DATABASE")))
+	conn := mustConnect(b, mustParseConfig(b, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase)))
 	defer closeConn(b, conn)
 
 	mustExec(b, conn, benchmarkWriteTableCreateSQL)
@@ -520,7 +520,7 @@ func multiInsert(conn *gaussdbgo.Conn, tableName string, columnNames []string, r
 }
 
 func benchmarkWriteNRowsViaMultiInsert(b *testing.B, n int) {
-	conn := mustConnect(b, mustParseConfig(b, os.Getenv("PGX_TEST_DATABASE")))
+	conn := mustConnect(b, mustParseConfig(b, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase)))
 	defer closeConn(b, conn)
 
 	mustExec(b, conn, benchmarkWriteTableCreateSQL)
@@ -556,7 +556,7 @@ func benchmarkWriteNRowsViaMultiInsert(b *testing.B, n int) {
 }
 
 func benchmarkWriteNRowsViaCopy(b *testing.B, n int) {
-	conn := mustConnect(b, mustParseConfig(b, os.Getenv("PGX_TEST_DATABASE")))
+	conn := mustConnect(b, mustParseConfig(b, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase)))
 	defer closeConn(b, conn)
 
 	mustExec(b, conn, benchmarkWriteTableCreateSQL)
@@ -681,7 +681,7 @@ func BenchmarkWrite10000RowsViaCopy(b *testing.B) {
 }
 
 func BenchmarkMultipleQueriesNonBatchNoStatementCache(b *testing.B) {
-	config := mustParseConfig(b, os.Getenv("PGX_TEST_DATABASE"))
+	config := mustParseConfig(b, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	config.DefaultQueryExecMode = gaussdbgo.QueryExecModeDescribeExec
 	config.StatementCacheCapacity = 0
 	config.DescriptionCacheCapacity = 0
@@ -693,7 +693,7 @@ func BenchmarkMultipleQueriesNonBatchNoStatementCache(b *testing.B) {
 }
 
 func BenchmarkMultipleQueriesNonBatchPrepareStatementCache(b *testing.B) {
-	config := mustParseConfig(b, os.Getenv("PGX_TEST_DATABASE"))
+	config := mustParseConfig(b, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	config.DefaultQueryExecMode = gaussdbgo.QueryExecModeCacheStatement
 	config.StatementCacheCapacity = 32
 	config.DescriptionCacheCapacity = 0
@@ -705,7 +705,7 @@ func BenchmarkMultipleQueriesNonBatchPrepareStatementCache(b *testing.B) {
 }
 
 func BenchmarkMultipleQueriesNonBatchDescribeStatementCache(b *testing.B) {
-	config := mustParseConfig(b, os.Getenv("PGX_TEST_DATABASE"))
+	config := mustParseConfig(b, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	config.DefaultQueryExecMode = gaussdbgo.QueryExecModeCacheDescribe
 	config.StatementCacheCapacity = 0
 	config.DescriptionCacheCapacity = 32
@@ -743,7 +743,7 @@ func benchmarkMultipleQueriesNonBatch(b *testing.B, conn *gaussdbgo.Conn, queryC
 }
 
 func BenchmarkMultipleQueriesBatchNoStatementCache(b *testing.B) {
-	config := mustParseConfig(b, os.Getenv("PGX_TEST_DATABASE"))
+	config := mustParseConfig(b, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	config.DefaultQueryExecMode = gaussdbgo.QueryExecModeDescribeExec
 	config.StatementCacheCapacity = 0
 	config.DescriptionCacheCapacity = 0
@@ -755,7 +755,7 @@ func BenchmarkMultipleQueriesBatchNoStatementCache(b *testing.B) {
 }
 
 func BenchmarkMultipleQueriesBatchPrepareStatementCache(b *testing.B) {
-	config := mustParseConfig(b, os.Getenv("PGX_TEST_DATABASE"))
+	config := mustParseConfig(b, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	config.DefaultQueryExecMode = gaussdbgo.QueryExecModeCacheStatement
 	config.StatementCacheCapacity = 32
 	config.DescriptionCacheCapacity = 0
@@ -767,7 +767,7 @@ func BenchmarkMultipleQueriesBatchPrepareStatementCache(b *testing.B) {
 }
 
 func BenchmarkMultipleQueriesBatchDescribeStatementCache(b *testing.B) {
-	config := mustParseConfig(b, os.Getenv("PGX_TEST_DATABASE"))
+	config := mustParseConfig(b, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	config.DefaultQueryExecMode = gaussdbgo.QueryExecModeCacheDescribe
 	config.StatementCacheCapacity = 0
 	config.DescriptionCacheCapacity = 32
@@ -817,7 +817,7 @@ func benchmarkMultipleQueriesBatch(b *testing.B, conn *gaussdbgo.Conn, queryCoun
 }
 
 func BenchmarkSelectManyUnknownEnum(b *testing.B) {
-	conn := mustConnectString(b, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(b, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(b, conn)
 
 	ctx := context.Background()
@@ -863,7 +863,7 @@ func BenchmarkSelectManyUnknownEnum(b *testing.B) {
 }
 
 func BenchmarkSelectManyRegisteredEnum(b *testing.B) {
-	conn := mustConnectString(b, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(b, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(b, conn)
 
 	ctx := context.Background()
@@ -917,12 +917,12 @@ func BenchmarkSelectManyRegisteredEnum(b *testing.B) {
 func getSelectRowsCounts(b *testing.B) []int64 {
 	var rowCounts []int64
 	{
-		s := os.Getenv("PGX_BENCH_SELECT_ROWS_COUNTS")
+		s := os.Getenv(gaussdbgo.EnvGaussdbBenchSelectRowsCounts)
 		if s != "" {
 			for _, p := range strings.Split(s, " ") {
 				n, err := strconv.ParseInt(p, 10, 64)
 				if err != nil {
-					b.Fatalf("Bad PGX_BENCH_SELECT_ROWS_COUNTS value: %v", err)
+					b.Fatalf("Bad GAUSSDB_BENCH_SELECT_ROWS_COUNTS value: %v", err)
 				}
 				rowCounts = append(rowCounts, n)
 			}
@@ -948,7 +948,7 @@ type BenchRowSimple struct {
 }
 
 func BenchmarkSelectRowsScanSimple(b *testing.B) {
-	conn := mustConnectString(b, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(b, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(b, conn)
 
 	rowCounts := getSelectRowsCounts(b)
@@ -986,7 +986,7 @@ type BenchRowStringBytes struct {
 }
 
 func BenchmarkSelectRowsScanStringBytes(b *testing.B) {
-	conn := mustConnectString(b, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(b, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(b, conn)
 
 	rowCounts := getSelectRowsCounts(b)
@@ -1024,7 +1024,7 @@ type BenchRowDecoder struct {
 }
 
 func BenchmarkSelectRowsScanDecoder(b *testing.B) {
-	conn := mustConnectString(b, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(b, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(b, conn)
 
 	rowCounts := getSelectRowsCounts(b)
@@ -1068,7 +1068,7 @@ func BenchmarkSelectRowsScanDecoder(b *testing.B) {
 }
 
 func BenchmarkSelectRowsGaussdbConnExecText(b *testing.B) {
-	conn := mustConnectString(b, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(b, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(b, conn)
 
 	rowCounts := getSelectRowsCounts(b)
@@ -1094,7 +1094,7 @@ func BenchmarkSelectRowsGaussdbConnExecText(b *testing.B) {
 }
 
 func BenchmarkSelectRowsGaussdbConnExecParams(b *testing.B) {
-	conn := mustConnectString(b, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(b, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(b, conn)
 
 	rowCounts := getSelectRowsCounts(b)
@@ -1135,7 +1135,7 @@ func BenchmarkSelectRowsGaussdbConnExecParams(b *testing.B) {
 }
 
 func BenchmarkSelectRowsSimpleCollectRowsRowToStructByPos(b *testing.B) {
-	conn := mustConnectString(b, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(b, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(b, conn)
 
 	rowCounts := getSelectRowsCounts(b)
@@ -1157,7 +1157,7 @@ func BenchmarkSelectRowsSimpleCollectRowsRowToStructByPos(b *testing.B) {
 }
 
 func BenchmarkSelectRowsSimpleAppendRowsRowToStructByPos(b *testing.B) {
-	conn := mustConnectString(b, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(b, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(b, conn)
 
 	rowCounts := getSelectRowsCounts(b)
@@ -1182,7 +1182,7 @@ func BenchmarkSelectRowsSimpleAppendRowsRowToStructByPos(b *testing.B) {
 }
 
 func BenchmarkSelectRowsSimpleCollectRowsRowToStructByName(b *testing.B) {
-	conn := mustConnectString(b, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(b, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(b, conn)
 
 	rowCounts := getSelectRowsCounts(b)
@@ -1204,7 +1204,7 @@ func BenchmarkSelectRowsSimpleCollectRowsRowToStructByName(b *testing.B) {
 }
 
 func BenchmarkSelectRowsSimpleAppendRowsRowToStructByName(b *testing.B) {
-	conn := mustConnectString(b, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(b, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(b, conn)
 
 	rowCounts := getSelectRowsCounts(b)
@@ -1229,7 +1229,7 @@ func BenchmarkSelectRowsSimpleAppendRowsRowToStructByName(b *testing.B) {
 }
 
 func BenchmarkSelectRowsGaussdbConnExecPrepared(b *testing.B) {
-	conn := mustConnectString(b, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(b, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(b, conn)
 
 	rowCounts := getSelectRowsCounts(b)
@@ -1332,7 +1332,7 @@ func BenchmarkSelectRowsRawPrepared(b *testing.B) {
 			}
 			for _, format := range formats {
 				b.Run(format.name, func(b *testing.B) {
-					conn := mustConnectString(b, os.Getenv("PGX_TEST_DATABASE")).GaussdbConn()
+					conn := mustConnectString(b, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase)).GaussdbConn()
 					defer conn.Close(context.Background())
 
 					_, err := conn.Prepare(context.Background(), "ps1", "select n, 'Adam', 'Smith ' || n, 'male', '1952-06-16'::date, 258, 72, '2001-01-28 01:02:03-05'::timestamptz from generate_series(100001, 100000 + $1) n", nil)

--- a/conn_internal_test.go
+++ b/conn_internal_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/HuaweiCloudDeveloper/gaussdb-go/gaussdbxtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -30,7 +29,7 @@ func mustConnect(t testing.TB, config *ConnConfig) *Conn {
 func TestStmtCacheSizeLimit(t *testing.T) {
 	const cacheLimit = 16
 
-	connConfig := mustParseConfig(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
+	connConfig := mustParseConfig(t, os.Getenv(EnvGaussdbTestDatabase))
 	connConfig.StatementCacheCapacity = cacheLimit
 	conn := mustConnect(t, connConfig)
 	defer func() {

--- a/conn_internal_test.go
+++ b/conn_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/HuaweiCloudDeveloper/gaussdb-go/gaussdbxtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -29,7 +30,7 @@ func mustConnect(t testing.TB, config *ConnConfig) *Conn {
 func TestStmtCacheSizeLimit(t *testing.T) {
 	const cacheLimit = 16
 
-	connConfig := mustParseConfig(t, os.Getenv("PGX_TEST_DATABASE"))
+	connConfig := mustParseConfig(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	connConfig.StatementCacheCapacity = cacheLimit
 	conn := mustConnect(t, connConfig)
 	defer func() {

--- a/conn_test.go
+++ b/conn_test.go
@@ -20,9 +20,9 @@ import (
 func TestCrateDBConnect(t *testing.T) {
 	t.Parallel()
 
-	connString := os.Getenv("PGX_TEST_CRATEDB_CONN_STRING")
+	connString := os.Getenv(gaussdbgo.EnvGaussdbTestCratedbConnString)
 	if connString == "" {
-		t.Skipf("Skipping due to missing environment variable %v", "PGX_TEST_CRATEDB_CONN_STRING")
+		t.Skipf("Skipping due to missing environment variable %v", gaussdbgo.EnvGaussdbTestCratedbConnString)
 	}
 
 	conn, err := gaussdbgo.Connect(context.Background(), connString)
@@ -44,7 +44,7 @@ func TestCrateDBConnect(t *testing.T) {
 func TestConnect(t *testing.T) {
 	t.Parallel()
 
-	connString := os.Getenv("PGX_TEST_DATABASE")
+	connString := os.Getenv(gaussdbgo.EnvGaussdbTestDatabase)
 	config := mustParseConfig(t, connString)
 
 	conn, err := gaussdbgo.ConnectConfig(context.Background(), config)
@@ -81,7 +81,7 @@ func TestConnect(t *testing.T) {
 func TestConnectWithPreferSimpleProtocol(t *testing.T) {
 	t.Parallel()
 
-	connConfig := mustParseConfig(t, os.Getenv("PGX_TEST_DATABASE"))
+	connConfig := mustParseConfig(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	connConfig.DefaultQueryExecMode = gaussdbgo.QueryExecModeSimpleProtocol
 
 	conn := mustConnect(t, connConfig)
@@ -106,7 +106,7 @@ func TestConnectConfigRequiresConnConfigFromParseConfig(t *testing.T) {
 }
 
 func TestConfigContainsConnStr(t *testing.T) {
-	connStr := os.Getenv("PGX_TEST_DATABASE")
+	connStr := os.Getenv(gaussdbgo.EnvGaussdbTestDatabase)
 	config, err := gaussdbgo.ParseConfig(connStr)
 	require.NoError(t, err)
 	assert.Equal(t, connStr, config.ConnString())
@@ -122,7 +122,7 @@ func TestConfigCopyReturnsEqualConfig(t *testing.T) {
 }
 
 func TestConfigCopyCanBeUsedToConnect(t *testing.T) {
-	connString := os.Getenv("PGX_TEST_DATABASE")
+	connString := os.Getenv(gaussdbgo.EnvGaussdbTestDatabase)
 	original, err := gaussdbgo.ParseConfig(connString)
 	require.NoError(t, err)
 
@@ -376,7 +376,7 @@ func TestExecContextFailureWithoutCancelationWithArguments(t *testing.T) {
 func TestExecFailureCloseBefore(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	closeConn(t, conn)
 
 	_, err := conn.Exec(context.Background(), "select 1")
@@ -387,7 +387,7 @@ func TestExecFailureCloseBefore(t *testing.T) {
 func TestExecPerQuerySimpleProtocol(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
@@ -418,7 +418,7 @@ func TestExecPerQuerySimpleProtocol(t *testing.T) {
 func TestPrepare(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	_, err := conn.Prepare(context.Background(), "test", "select $1::varchar")
@@ -470,7 +470,7 @@ func TestPrepare(t *testing.T) {
 func TestPrepareBadSQLFailure(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	if _, err := conn.Prepare(context.Background(), "badSQL", "select foo"); err == nil {
@@ -617,7 +617,7 @@ func TestDeallocateMissingPreparedStatementStillClearsFromPreparedStatementMap(t
 /*func TestListenNotify(t *testing.T) {
 	t.Parallel()
 
-	listener := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	listener := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, listener)
 
 	if listener.GaussdbConn().ParameterStatus("crdb_version") != "" {
@@ -626,7 +626,7 @@ func TestDeallocateMissingPreparedStatementStillClearsFromPreparedStatementMap(t
 
 	mustExec(t, listener, "listen chat")
 
-	notifier := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	notifier := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, notifier)
 
 	mustExec(t, notifier, "notify chat")
@@ -667,7 +667,7 @@ func TestDeallocateMissingPreparedStatementStillClearsFromPreparedStatementMap(t
 	t.Parallel()
 
 	func() {
-		conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+		conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 		defer closeConn(t, conn)
 	}()
 
@@ -675,7 +675,7 @@ func TestDeallocateMissingPreparedStatementStillClearsFromPreparedStatementMap(t
 	notifierDone := make(chan bool)
 	listening := make(chan bool)
 	go func() {
-		conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+		conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 		defer closeConn(t, conn)
 		defer func() {
 			listenerDone <- true
@@ -722,7 +722,7 @@ func TestDeallocateMissingPreparedStatementStillClearsFromPreparedStatementMap(t
 	}()
 
 	go func() {
-		conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+		conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 		defer closeConn(t, conn)
 		defer func() {
 			notifierDone <- true
@@ -743,7 +743,7 @@ func TestDeallocateMissingPreparedStatementStillClearsFromPreparedStatementMap(t
 //func TestListenNotifySelfNotification(t *testing.T) {
 //	t.Parallel()
 //
-//	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+//	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 //	defer closeConn(t, conn)
 //
 //	mustExec(t, conn, "listen self")
@@ -776,7 +776,7 @@ func TestDeallocateMissingPreparedStatementStillClearsFromPreparedStatementMap(t
 // todo: conn.GaussdbConn().PID() not return the right pid.
 //func TestFatalRxError(t *testing.T) {
 //	t.Parallel()
-//	envVar := os.Getenv("PGX_TEST_DATABASE")
+//	envVar := os.Getenv(gaussdbgo.EnvGaussdbTestDatabase)
 //
 //	conn := mustConnectString(t, envVar)
 //	defer closeConn(t, conn)
@@ -816,10 +816,10 @@ func TestDeallocateMissingPreparedStatementStillClearsFromPreparedStatementMap(t
 //	// Run timing sensitive test many times
 //	for i := 0; i < 50; i++ {
 //		func() {
-//			conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+//			conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 //			defer closeConn(t, conn)
 //
-//			otherConn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+//			otherConn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 //			defer otherConn.Close(context.Background())
 //
 //			_, err := otherConn.Exec(context.Background(), "select pg_terminate_backend($1)", conn.GaussdbConn().PID())
@@ -917,7 +917,7 @@ func TestIdentifierSanitize(t *testing.T) {
 }
 
 func TestConnInitTypeMap(t *testing.T) {
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	// spot check that the standard gaussdb type names aren't qualified
@@ -1149,7 +1149,7 @@ func TestLoadRangeType(t *testing.T) {
 func TestStmtCacheInvalidationConn(t *testing.T) {
 	ctx := context.Background()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	// create a table and fill it with some data
@@ -1212,7 +1212,7 @@ func TestStmtCacheInvalidationConn(t *testing.T) {
 func TestStmtCacheInvalidationTx(t *testing.T) {
 	ctx := context.Background()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	// create a table and fill it with some data
@@ -1366,7 +1366,7 @@ func TestConnDeallocateInvalidatedCachedStatementsInTransactionWithBatch(t *test
 
 	ctx := context.Background()
 
-	connString := os.Getenv("PGX_TEST_DATABASE")
+	connString := os.Getenv(gaussdbgo.EnvGaussdbTestDatabase)
 	config := mustParseConfig(t, connString)
 	config.DefaultQueryExecMode = gaussdbgo.QueryExecModeCacheStatement
 	config.StatementCacheCapacity = 2

--- a/conn_test.go
+++ b/conn_test.go
@@ -1192,7 +1192,7 @@ func TestStmtCacheInvalidationConn(t *testing.T) {
 		if err == nil {
 			t.Fatal(`expected "Cached plan must not change result type": no error`)
 		}
-		if !strings.Contains(err.Error(), "Cached plan must not change result type") {
+		if !strings.Contains(err.Error(), lowerFirstLetterInError("Cached plan must not change result type")) {
 			t.Fatalf(`expected "Cached plan must not change result type", got: "%s"`, err.Error())
 		}
 	}
@@ -1253,12 +1253,12 @@ func TestStmtCacheInvalidationTx(t *testing.T) {
 	rows.Next()
 	nextErr := rows.Err()
 	rows.Close()
+	// opengauss always return "cached ...", gaussdb return "Cached ..."
 	for _, err := range []error{nextErr, rows.Err()} {
-		// todo: opengauss always return "cached ...", gaussdb return "Cached ..."
 		if err == nil {
 			t.Fatal(`expected "Cached plan must not change result type": no error`)
 		}
-		if !strings.Contains(err.Error(), "Cached plan must not change result type") {
+		if !strings.Contains(err.Error(), lowerFirstLetterInError("Cached plan must not change result type")) {
 			t.Fatalf(`expected "Cached plan must not change result type", got: "%s"`, err.Error())
 		}
 	}

--- a/copy_from_test.go
+++ b/copy_from_test.go
@@ -20,7 +20,7 @@ func TestConnCopyWithAllQueryExecModes(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 			defer cancel()
 
-			cfg := mustParseConfig(t, os.Getenv("PGX_TEST_DATABASE"))
+			cfg := mustParseConfig(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 			cfg.DefaultQueryExecMode = mode
 			conn := mustConnect(t, cfg)
 			defer closeConn(t, conn)
@@ -87,7 +87,7 @@ func TestConnCopyWithKnownOIDQueryExecModes(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 			defer cancel()
 
-			cfg := mustParseConfig(t, os.Getenv("PGX_TEST_DATABASE"))
+			cfg := mustParseConfig(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 			cfg.DefaultQueryExecMode = mode
 			conn := mustConnect(t, cfg)
 			defer closeConn(t, conn)
@@ -150,7 +150,7 @@ func TestConnCopyFromSmall(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	mustExec(t, conn, `create temporary table foo(
@@ -209,7 +209,7 @@ func TestConnCopyFromSliceSmall(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	mustExec(t, conn, `create temporary table foo(
@@ -271,7 +271,7 @@ func TestConnCopyFromLarge(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	mustExec(t, conn, `create temporary table foo(
@@ -332,7 +332,7 @@ func TestConnCopyFromEnum(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	tx, err := conn.Begin(ctx)
@@ -406,7 +406,7 @@ func TestConnCopyFromJSON(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	for _, typeName := range []string{"json", "jsonb"} {
@@ -486,7 +486,7 @@ func TestConnCopyFromFailServerSideMidway(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	mustExec(t, conn, `create temporary table foo(
@@ -565,7 +565,7 @@ func TestConnCopyFromFailServerSideMidwayAbortsWithoutWaiting(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	mustExec(t, conn, `create temporary table foo(
@@ -643,7 +643,7 @@ func TestConnCopyFromSlowFailRace(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	mustExec(t, conn, `create temporary table foo(
@@ -671,7 +671,7 @@ func TestConnCopyFromCopyFromSourceErrorMidway(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	mustExec(t, conn, `create temporary table foo(
@@ -734,7 +734,7 @@ func TestConnCopyFromCopyFromSourceErrorEnd(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	mustExec(t, conn, `create temporary table foo(
@@ -780,7 +780,7 @@ func TestConnCopyFromAutomaticStringConversion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	mustExec(t, conn, `create temporary table foo(
@@ -812,7 +812,7 @@ func TestConnCopyFromAutomaticStringConversionArray(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	mustExec(t, conn, `create temporary table foo(
@@ -842,7 +842,7 @@ func TestConnCopyFromAutomaticStringConversionArray(t *testing.T) {
 func TestCopyFromFunc(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	mustExec(t, conn, `create temporary table foo(

--- a/env.go
+++ b/env.go
@@ -1,5 +1,7 @@
 package gaussdbgo
 
+import "os"
+
 // this just defines some environment variables that are used in the tests
 const (
 	EnvGaussdbTestDatabase            = "GAUSSDB_TEST_DATABASE"
@@ -13,3 +15,7 @@ const (
 	EnvGaussdbTestTlsConnString       = "GAUSSDB_TEST_TLS_CONN_STRING"
 	EnvIsOpengauss                    = "IS_OPENGAUSS"
 )
+
+func IsTestingWithOpengauss() bool {
+	return os.Getenv(EnvIsOpengauss) == "true"
+}

--- a/env.go
+++ b/env.go
@@ -1,0 +1,15 @@
+package gaussdbgo
+
+// this just defines some environment variables that are used in the tests
+const (
+	EnvGaussdbTestDatabase            = "GAUSSDB_TEST_DATABASE"
+	EnvGaussdbBenchSelectRowsCounts   = "GAUSSDB_BENCH_SELECT_ROWS_COUNTS"
+	EnvGaussdbSslPassword             = "GAUSSDB_SSL_PASSWORD"
+	EnvGaussdbTestCratedbConnString   = "GAUSSDB_TEST_CRATEDB_CONN_STRING"
+	EnvGaussdbTestPgbouncerConnString = "GAUSSDB_TEST_PGBOUNCER_CONN_STRING"
+	EnvGaussdbTestStressFactor        = "GAUSSDB_TEST_STRESS_FACTOR"
+	EnvGaussdbTestTcpConnString       = "GAUSSDB_TEST_TCP_CONN_STRING"
+	EnvGaussdbTestTlsClientConnString = "GAUSSDB_TEST_TLS_CLIENT_CONN_STRING"
+	EnvGaussdbTestTlsConnString       = "GAUSSDB_TEST_TLS_CONN_STRING"
+	EnvIsOpengauss                    = "IS_OPENGAUSS"
+)

--- a/gaussdbconn/benchmark_test.go
+++ b/gaussdbconn/benchmark_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	gaussdbgo "github.com/HuaweiCloudDeveloper/gaussdb-go"
 	"github.com/HuaweiCloudDeveloper/gaussdb-go/gaussdbconn"
 	"github.com/stretchr/testify/require"
 )
@@ -16,8 +17,8 @@ func BenchmarkConnect(b *testing.B) {
 		env  string
 	}{
 		// todo: unix socket to improve
-		//{"Unix socket", "PGX_TEST_UNIX_SOCKET_CONN_STRING"},
-		{"TCP", "PGX_TEST_TCP_CONN_STRING"},
+		//{"Unix socket", "GAUSSDB_TEST_UNIX_SOCKET_CONN_STRING"},
+		{"TCP", gaussdbgo.EnvGaussdbTestTcpConnString},
 	}
 
 	for _, bm := range benchmarks {
@@ -54,7 +55,7 @@ func BenchmarkExec(b *testing.B) {
 	for _, bm := range benchmarks {
 		bm := bm
 		b.Run(bm.name, func(b *testing.B) {
-			conn, err := gaussdbconn.Connect(bm.ctx, os.Getenv("PGX_TEST_DATABASE"))
+			conn, err := gaussdbconn.Connect(bm.ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 			require.Nil(b, err)
 			defer closeConn(b, conn)
 
@@ -98,7 +99,7 @@ func BenchmarkExec(b *testing.B) {
 }
 
 func BenchmarkExecPossibleToCancel(b *testing.B) {
-	conn, err := gaussdbconn.Connect(context.Background(), os.Getenv("PGX_TEST_DATABASE"))
+	conn, err := gaussdbconn.Connect(context.Background(), os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.Nil(b, err)
 	defer closeConn(b, conn)
 
@@ -160,7 +161,7 @@ func BenchmarkExecPrepared(b *testing.B) {
 	for _, bm := range benchmarks {
 		bm := bm
 		b.Run(bm.name, func(b *testing.B) {
-			conn, err := gaussdbconn.Connect(bm.ctx, os.Getenv("PGX_TEST_DATABASE"))
+			conn, err := gaussdbconn.Connect(bm.ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 			require.Nil(b, err)
 			defer closeConn(b, conn)
 
@@ -198,7 +199,7 @@ func BenchmarkExecPrepared(b *testing.B) {
 }
 
 func BenchmarkExecPreparedPossibleToCancel(b *testing.B) {
-	conn, err := gaussdbconn.Connect(context.Background(), os.Getenv("PGX_TEST_DATABASE"))
+	conn, err := gaussdbconn.Connect(context.Background(), os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.Nil(b, err)
 	defer closeConn(b, conn)
 
@@ -239,7 +240,7 @@ func BenchmarkExecPreparedPossibleToCancel(b *testing.B) {
 }
 
 // func BenchmarkChanToSetDeadlinePossibleToCancel(b *testing.B) {
-// 	conn, err := gaussdbconn.Connect(context.Background(), os.Getenv("PGX_TEST_DATABASE"))
+// 	conn, err := gaussdbconn.Connect(context.Background(), os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 // 	require.Nil(b, err)
 // 	defer closeConn(b, conn)
 

--- a/gaussdbconn/config.go
+++ b/gaussdbconn/config.go
@@ -68,7 +68,7 @@ type Config struct {
 	// OnNotification is a callback function called when a notification from the LISTEN/NOTIFY system is received.
 	OnNotification NotificationHandler
 
-	// OnGaussdbError is a callback function called when a Postgres error is received by the server. The default handler will close
+	// OnGaussdbError is a callback function called when a Gaussdb error is received by the server. The default handler will close
 	// the connection on any FATAL errors. If you override this handler you should call the previously set handler or ensure
 	// that you close on FATAL errors by returning false.
 	OnGaussdbError GaussdbErrorHandler

--- a/gaussdbconn/config_test.go
+++ b/gaussdbconn/config_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	gaussdbgo "github.com/HuaweiCloudDeveloper/gaussdb-go"
 	"github.com/HuaweiCloudDeveloper/gaussdb-go/gaussdbconn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -814,7 +815,7 @@ func TestConfigCopyOriginalConfigDidNotChange(t *testing.T) {
 }
 
 func TestConfigCopyCanBeUsedToConnect(t *testing.T) {
-	connString := os.Getenv("PGX_TEST_DATABASE")
+	connString := os.Getenv(gaussdbgo.EnvGaussdbTestDatabase)
 	original, err := gaussdbconn.ParseConfig(connString)
 	require.NoError(t, err)
 

--- a/gaussdbconn/gaussdbconn.go
+++ b/gaussdbconn/gaussdbconn.go
@@ -53,7 +53,7 @@ type LookupFunc func(ctx context.Context, host string) (addrs []string, err erro
 // BuildFrontendFunc is a function that can be used to create Frontend implementation for connection.
 type BuildFrontendFunc func(r io.Reader, w io.Writer) *gaussdbproto.Frontend
 
-// GaussdbErrorHandler is a function that handles errors returned from Postgres. This function must return true to keep
+// GaussdbErrorHandler is a function that handles errors returned from Gaussdb. This function must return true to keep
 // the connection open. Returning false will cause the connection to be closed immediately. You should return
 // false on any FATAL-severity errors. This will not receive network errors. The *GaussdbConn is provided so the handler is
 // aware of the origin of the error, but it must not invoke any query method.
@@ -991,7 +991,7 @@ func (gaussdbConn *GaussdbConn) CancelRequest(ctx context.Context) error {
 	var serverAddress string
 	if serverAddr.Network() == "unix" {
 		// for unix sockets, RemoteAddr() calls getpeername() which returns the name the
-		// server passed to bind(). For Postgres, this is always a relative path "./.s.PGSQL.5432"
+		// server passed to bind(). For Gaussdb, this is always a relative path "./.s.PGSQL.5432"
 		// so connecting to it will fail. Fall back to the config's value
 		serverNetwork, serverAddress = NetworkAddress(gaussdbConn.config.Host, gaussdbConn.config.Port)
 	} else {

--- a/gaussdbconn/gaussdbconn_stress_test.go
+++ b/gaussdbconn/gaussdbconn_stress_test.go
@@ -8,20 +8,21 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/HuaweiCloudDeveloper/gaussdb-go"
 	"github.com/HuaweiCloudDeveloper/gaussdb-go/gaussdbconn"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestConnStress(t *testing.T) {
-	gaussdbConn, err := gaussdbconn.Connect(context.Background(), os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(context.Background(), os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
 	actionCount := 10000
-	if s := os.Getenv("PGX_TEST_STRESS_FACTOR"); s != "" {
+	if s := os.Getenv(gaussdbgo.EnvGaussdbTestStressFactor); s != "" {
 		stressFactor, err := strconv.ParseInt(s, 10, 64)
-		require.Nil(t, err, "Failed to parse PGX_TEST_STRESS_FACTOR")
+		require.Nil(t, err, "Failed to parse GAUSSDB_TEST_STRESS_FACTOR")
 		actionCount *= int(stressFactor)
 	}
 

--- a/gaussdbconn/gaussdbconn_stress_test.go
+++ b/gaussdbconn/gaussdbconn_stress_test.go
@@ -2,6 +2,7 @@ package gaussdbconn_test
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"os"
 	"runtime"
@@ -22,7 +23,7 @@ func TestConnStress(t *testing.T) {
 	actionCount := 10000
 	if s := os.Getenv(gaussdbgo.EnvGaussdbTestStressFactor); s != "" {
 		stressFactor, err := strconv.ParseInt(s, 10, 64)
-		require.Nil(t, err, "Failed to parse GAUSSDB_TEST_STRESS_FACTOR")
+		require.Nil(t, err, fmt.Sprintf("Failed to parse %s", gaussdbgo.EnvGaussdbTestStressFactor))
 		actionCount *= int(stressFactor)
 	}
 

--- a/gaussdbconn/gaussdbconn_test.go
+++ b/gaussdbconn/gaussdbconn_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 // TODO: remove pgbouncer?
-const pgbouncerConnStringEnvVar = "PGX_TEST_PGBOUNCER_CONN_STRING"
+const pgbouncerConnStringEnvVar = gaussdbgo.EnvGaussdbTestPgbouncerConnString
 
 func TestConnect(t *testing.T) {
 	tests := []struct {
@@ -38,11 +38,11 @@ func TestConnect(t *testing.T) {
 		env  string
 	}{
 		// todo: unix socket to improve
-		//{"Unix socket", "PGX_TEST_UNIX_SOCKET_CONN_STRING"},
-		{"TCP", "PGX_TEST_TCP_CONN_STRING"},
-		{"Plain password", "PGX_TEST_PLAIN_PASSWORD_CONN_STRING"},
-		{"MD5 password", "PGX_TEST_MD5_PASSWORD_CONN_STRING"},
-		{"SCRAM password", "PGX_TEST_SCRAM_PASSWORD_CONN_STRING"},
+		//{"Unix socket", "GAUSSDB_TEST_UNIX_SOCKET_CONN_STRING"},
+		{"TCP", gaussdbgo.EnvGaussdbTestTcpConnString},
+		{"Plain password", "GAUSSDB_TEST_PLAIN_PASSWORD_CONN_STRING"},
+		{"MD5 password", "GAUSSDB_TEST_MD5_PASSWORD_CONN_STRING"},
+		{"SCRAM password", "GAUSSDB_TEST_SCRAM_PASSWORD_CONN_STRING"},
 	}
 
 	for _, tt := range tests {
@@ -70,11 +70,11 @@ func TestConnectWithOptions(t *testing.T) {
 		env  string
 	}{
 		// todo: unix socket to improve
-		//{"Unix socket", "PGX_TEST_UNIX_SOCKET_CONN_STRING"},
-		{"TCP", "PGX_TEST_TCP_CONN_STRING"},
-		{"Plain password", "PGX_TEST_PLAIN_PASSWORD_CONN_STRING"},
-		{"MD5 password", "PGX_TEST_MD5_PASSWORD_CONN_STRING"},
-		{"SCRAM password", "PGX_TEST_SCRAM_PASSWORD_CONN_STRING"},
+		//{"Unix socket", "GAUSSDB_TEST_UNIX_SOCKET_CONN_STRING"},
+		{"TCP", gaussdbgo.EnvGaussdbTestTcpConnString},
+		{"Plain password", "GAUSSDB_TEST_PLAIN_PASSWORD_CONN_STRING"},
+		{"MD5 password", "GAUSSDB_TEST_MD5_PASSWORD_CONN_STRING"},
+		{"SCRAM password", "GAUSSDB_TEST_SCRAM_PASSWORD_CONN_STRING"},
 	}
 
 	for _, tt := range tests {
@@ -105,9 +105,9 @@ func TestConnectTLS(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	connString := os.Getenv("PGX_TEST_TLS_CONN_STRING")
+	connString := os.Getenv(gaussdbgo.EnvGaussdbTestTlsConnString)
 	if connString == "" {
-		t.Skipf("Skipping due to missing environment variable %v", "PGX_TEST_TLS_CONN_STRING")
+		t.Skipf("Skipping due to missing environment variable %v", gaussdbgo.EnvGaussdbTestTlsConnString)
 	}
 
 	conn, err := gaussdbconn.Connect(ctx, connString)
@@ -128,15 +128,15 @@ func TestConnectTLSPasswordProtectedClientCertWithSSLPassword(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	connString := os.Getenv("PGX_TEST_TLS_CLIENT_CONN_STRING")
+	connString := os.Getenv(gaussdbgo.EnvGaussdbTestTlsClientConnString)
 	if connString == "" {
-		t.Skipf("Skipping due to missing environment variable %v", "PGX_TEST_TLS_CLIENT_CONN_STRING")
+		t.Skipf("Skipping due to missing environment variable %v", gaussdbgo.EnvGaussdbTestTlsClientConnString)
 	}
-	if os.Getenv("PGX_SSL_PASSWORD") == "" {
-		t.Skipf("Skipping due to missing environment variable %v", "PGX_SSL_PASSWORD")
+	if os.Getenv(gaussdbgo.EnvGaussdbSslPassword) == "" {
+		t.Skipf("Skipping due to missing environment variable %v", gaussdbgo.EnvGaussdbSslPassword)
 	}
 
-	connString += " sslpassword=" + os.Getenv("PGX_SSL_PASSWORD")
+	connString += " sslpassword=" + os.Getenv(gaussdbgo.EnvGaussdbSslPassword)
 
 	conn, err := gaussdbconn.Connect(ctx, connString)
 	require.NoError(t, err)
@@ -156,13 +156,13 @@ func TestConnectTLSPasswordProtectedClientCertWithGetSSLPasswordConfigOption(t *
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	connString := os.Getenv("PGX_TEST_TLS_CLIENT_CONN_STRING")
+	connString := os.Getenv(gaussdbgo.EnvGaussdbTestTlsClientConnString)
 	// todo: need client cert
 	if connString == "" {
-		t.Skipf("Skipping due to missing environment variable %v", "PGX_TEST_TLS_CLIENT_CONN_STRING")
+		t.Skipf("Skipping due to missing environment variable %v", gaussdbgo.EnvGaussdbTestTlsClientConnString)
 	}
-	if os.Getenv("PGX_SSL_PASSWORD") == "" {
-		t.Skipf("Skipping due to missing environment variable %v", "PGX_SSL_PASSWORD")
+	if os.Getenv(gaussdbgo.EnvGaussdbSslPassword) == "" {
+		t.Skipf("Skipping due to missing environment variable %v", gaussdbgo.EnvGaussdbSslPassword)
 	}
 
 	var sslOptions gaussdbconn.ParseConfigOptions
@@ -345,13 +345,15 @@ func TestConnectTimeoutStuckOnTLSHandshake(t *testing.T) {
 
 func TestConnectInvalidUser(t *testing.T) {
 	t.Parallel()
-
+	if os.Getenv(gaussdbgo.EnvIsOpengauss) == "true" {
+		t.Skip("skip opengauss, use different protocol")
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	connString := os.Getenv("PGX_TEST_TCP_CONN_STRING")
+	connString := os.Getenv(gaussdbgo.EnvGaussdbTestTcpConnString)
 	if connString == "" {
-		t.Skipf("Skipping due to missing environment variable %v", "PGX_TEST_TCP_CONN_STRING")
+		t.Skipf("Skipping due to missing environment variable %v", gaussdbgo.EnvGaussdbTestTcpConnString)
 	}
 
 	config, err := gaussdbconn.ParseConfig(connString)
@@ -388,7 +390,7 @@ func TestConnectCustomDialer(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	config, err := gaussdbconn.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	config, err := gaussdbconn.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 
 	dialed := false
@@ -409,9 +411,9 @@ func TestConnectCustomLookup(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	connString := os.Getenv("PGX_TEST_TCP_CONN_STRING")
+	connString := os.Getenv(gaussdbgo.EnvGaussdbTestTcpConnString)
 	if connString == "" {
-		t.Skipf("Skipping due to missing environment variable %v", "PGX_TEST_TCP_CONN_STRING")
+		t.Skipf("Skipping due to missing environment variable %v", gaussdbgo.EnvGaussdbTestTcpConnString)
 	}
 
 	config, err := gaussdbconn.ParseConfig(connString)
@@ -435,9 +437,9 @@ func TestConnectCustomLookupWithPort(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	connString := os.Getenv("PGX_TEST_TCP_CONN_STRING")
+	connString := os.Getenv(gaussdbgo.EnvGaussdbTestTcpConnString)
 	if connString == "" {
-		t.Skipf("Skipping due to missing environment variable %v", "PGX_TEST_TCP_CONN_STRING")
+		t.Skipf("Skipping due to missing environment variable %v", gaussdbgo.EnvGaussdbTestTcpConnString)
 	}
 
 	config, err := gaussdbconn.ParseConfig(connString)
@@ -472,7 +474,7 @@ func TestConnectWithRuntimeParams(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	config, err := gaussdbconn.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	config, err := gaussdbconn.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 
 	config.RuntimeParams = map[string]string{
@@ -501,7 +503,7 @@ func TestConnectWithFallback(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	config, err := gaussdbconn.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	config, err := gaussdbconn.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 
 	// Prepend current primary config to fallbacks
@@ -553,7 +555,7 @@ func TestConnectWithValidateConnect(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	config, err := gaussdbconn.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	config, err := gaussdbconn.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 
 	dialCount := 0
@@ -595,7 +597,7 @@ func TestConnectWithValidateConnectTargetSessionAttrsReadWrite(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	config, err := gaussdbconn.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	config, err := gaussdbconn.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 
 	config.ValidateConnect = gaussdbconn.ValidateConnectTargetSessionAttrsReadWrite
@@ -613,7 +615,7 @@ func TestConnectWithAfterConnect(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	config, err := gaussdbconn.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	config, err := gaussdbconn.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 
 	config.AfterConnect = func(ctx context.Context, conn *gaussdbconn.GaussdbConn) error {
@@ -648,7 +650,7 @@ func TestConnPrepareSyntaxError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -665,7 +667,7 @@ func TestConnPrepareContextPrecanceled(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -686,7 +688,7 @@ func TestConnDeallocate(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -714,7 +716,7 @@ func TestConnDeallocateSucceedsInAbortedTransaction(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -753,7 +755,7 @@ func TestConnDeallocateNonExistantStatementSucceeds(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -769,7 +771,7 @@ func TestConnExec(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -791,7 +793,7 @@ func TestConnExecEmpty(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -815,7 +817,7 @@ func TestConnExecMultipleQueries(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -843,7 +845,7 @@ func TestConnExecMultipleQueriesEagerFieldDescriptions(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -874,7 +876,7 @@ func TestConnExecMultipleQueriesError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -899,7 +901,7 @@ func TestConnExecDeferredError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -930,7 +932,7 @@ func TestConnExecContextCanceled(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 	cancel()
@@ -958,7 +960,7 @@ func TestConnExecContextPrecanceled(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -977,7 +979,7 @@ func TestConnExecParams(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -1004,7 +1006,7 @@ func TestConnExecParamsDeferredError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -1034,7 +1036,7 @@ func TestConnExecParamsMaxNumberOfParams(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -1060,7 +1062,7 @@ func TestConnExecParamsTooManyParams(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -1086,7 +1088,7 @@ func TestConnExecParamsCanceled(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -1117,7 +1119,7 @@ func TestConnExecParamsPrecanceled(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -1136,7 +1138,7 @@ func TestConnExecParamsEmptySQL(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -1154,7 +1156,7 @@ func TestResultReaderValuesHaveSameCapacityAsLength(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -1182,7 +1184,7 @@ func TestResultReaderReadNil(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -1199,7 +1201,7 @@ func TestConnExecPrepared(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -1232,7 +1234,7 @@ func TestConnExecPreparedMaxNumberOfParams(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -1264,7 +1266,7 @@ func TestConnExecPreparedTooManyParams(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -1297,7 +1299,7 @@ func TestConnExecPreparedCanceled(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -1329,7 +1331,7 @@ func TestConnExecPreparedPrecanceled(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -1351,7 +1353,7 @@ func TestConnExecPreparedEmptySQL(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -1372,7 +1374,7 @@ func TestConnExecBatch(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -1417,7 +1419,7 @@ func TestConnExecBatchWriteError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	config, err := gaussdbconn.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	config, err := gaussdbconn.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 
 	var mockConn mockConnection
@@ -1453,7 +1455,7 @@ func TestConnExecBatchDeferredError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -1486,7 +1488,7 @@ func TestConnExecBatchPrecanceled(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -1519,7 +1521,7 @@ func TestConnExecBatchHuge(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -1550,7 +1552,7 @@ func TestConnExecBatchImplicitTransaction(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -1576,7 +1578,7 @@ func TestConnLocking(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -1603,7 +1605,7 @@ func TestConnOnNotice(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	config, err := gaussdbconn.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	config, err := gaussdbconn.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 
 	var notice *gaussdbconn.Notice
@@ -1637,7 +1639,7 @@ end$$;`)
 //	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 //	defer cancel()
 //
-//	config, err := gaussdbconn.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+//	config, err := gaussdbconn.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 //	require.NoError(t, err)
 //
 //	var msg string
@@ -1673,7 +1675,7 @@ end$$;`)
 //	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 //	defer cancel()
 //
-//	config, err := gaussdbconn.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+//	config, err := gaussdbconn.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 //	require.NoError(t, err)
 //
 //	var msg string
@@ -1708,7 +1710,7 @@ func TestConnWaitForNotificationPrecanceled(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	config, err := gaussdbconn.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	config, err := gaussdbconn.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 
 	gaussdbConn, err := gaussdbconn.ConnectConfig(ctx, config)
@@ -1728,7 +1730,7 @@ func TestConnWaitForNotificationTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	config, err := gaussdbconn.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	config, err := gaussdbconn.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 
 	gaussdbConn, err := gaussdbconn.ConnectConfig(ctx, config)
@@ -1750,7 +1752,7 @@ func TestConnCopyToSmall(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -1791,7 +1793,7 @@ func TestConnCopyToLarge(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -1832,7 +1834,7 @@ func TestConnCopyToQueryError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -1852,7 +1854,7 @@ func TestConnCopyToCanceled(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -1878,7 +1880,7 @@ func TestConnCopyToPrecanceled(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -1900,7 +1902,7 @@ func TestConnCopyFrom(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -1940,7 +1942,7 @@ func TestConnCopyFromBinary(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -1996,7 +1998,7 @@ func TestConnCopyFromCanceled(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -2040,7 +2042,7 @@ func TestConnCopyFromPrecanceled(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -2080,7 +2082,7 @@ func TestConnCopyFromGzipReader(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -2136,7 +2138,7 @@ func TestConnCopyFromQuerySyntaxError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -2173,7 +2175,7 @@ func TestConnCopyFromQueryNoTableError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -2193,7 +2195,7 @@ func TestConnCopyFromNoticeResponseReceivedMidStream(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 	// todo: gaussdb can't use temporary table here, complaints: Only support CREATE TRIGGER on regular row table. (SQLSTATE 0A000)
@@ -2244,9 +2246,9 @@ func TestConnCopyFromDataWriteAfterErrorAndReturn(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	connString := os.Getenv("PGX_TEST_DATABASE")
+	connString := os.Getenv(gaussdbgo.EnvGaussdbTestDatabase)
 	if connString == "" {
-		t.Skipf("Skipping due to missing environment variable %v", "PGX_TEST_DATABASE")
+		t.Skipf("Skipping due to missing environment variable %v", gaussdbgo.EnvGaussdbTestDatabase)
 	}
 
 	config, err := gaussdbconn.ParseConfig(connString)
@@ -2279,7 +2281,7 @@ func TestConnEscapeString(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -2310,7 +2312,7 @@ func TestConnCancelRequest(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -2345,7 +2347,7 @@ func TestConnContextCanceledCancelsRunningQueryOnServer(t *testing.T) {
 	t.Run("postgres", func(t *testing.T) {
 		t.Parallel()
 
-		testConnContextCanceledCancelsRunningQueryOnServer(t, os.Getenv("PGX_TEST_DATABASE"), "postgres")
+		testConnContextCanceledCancelsRunningQueryOnServer(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase), "postgres")
 	})
 
 	t.Run("pgbouncer", func(t *testing.T) {
@@ -2424,7 +2426,7 @@ func TestHijackAndConstruct(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	origConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	origConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 
 	err = origConn.SyncConn(ctx)
@@ -2459,7 +2461,7 @@ func TestConnCloseWhileCancellableQueryInProgress(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 
 	gaussdbConn.Exec(ctx, "select n from generate_series(1,10) n")
@@ -2544,7 +2546,7 @@ func TestConnLargeResponseWhileWritingDoesNotDeadlock(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -2579,9 +2581,9 @@ func TestConnLargeResponseWhileWritingDoesNotDeadlock(t *testing.T) {
 //
 //	// Intentionally using TCP connection for more predictable close behavior. (Not sure if Unix domain sockets would behave subtly different.)
 //
-//	connString := os.Getenv("PGX_TEST_TCP_CONN_STRING")
+//	connString := os.Getenv(gaussdbgo.EnvGaussdbTestTcpConnString)
 //	if connString == "" {
-//		t.Skipf("Skipping due to missing environment variable %v", "PGX_TEST_TCP_CONN_STRING")
+//		t.Skipf("Skipping due to missing environment variable %v", gaussdbgo.EnvGaussdbTestTcpConnString)
 //	}
 //
 //	c1, err := gaussdbconn.Connect(ctx, connString)
@@ -2615,9 +2617,9 @@ func TestConnPing(t *testing.T) {
 
 	// Intentionally using TCP connection for more predictable close behavior. (Not sure if Unix domain sockets would behave subtly different.)
 
-	connString := os.Getenv("PGX_TEST_TCP_CONN_STRING")
+	connString := os.Getenv(gaussdbgo.EnvGaussdbTestTcpConnString)
 	if connString == "" {
-		t.Skipf("Skipping due to missing environment variable %v", "PGX_TEST_TCP_CONN_STRING")
+		t.Skipf("Skipping due to missing environment variable %v", gaussdbgo.EnvGaussdbTestTcpConnString)
 	}
 
 	c1, err := gaussdbconn.Connect(ctx, connString)
@@ -2654,7 +2656,7 @@ func TestPipelinePrepare(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -2729,7 +2731,7 @@ func TestPipelinePrepareError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -2774,7 +2776,7 @@ func TestPipelinePrepareAndDeallocate(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -2818,7 +2820,7 @@ func TestPipelineQuery(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -2910,7 +2912,7 @@ func TestPipelinePrepareQuery(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -2970,7 +2972,7 @@ func TestPipelineQueryErrorBetweenSyncs(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -3077,7 +3079,7 @@ func TestPipelineFlushForSingleRequests(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -3176,7 +3178,7 @@ func TestPipelineFlushForRequestSeries(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -3325,7 +3327,7 @@ func TestPipelineFlushWithError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -3415,7 +3417,7 @@ func TestPipelineCloseReadsUnreadResults(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -3453,7 +3455,7 @@ func TestPipelineCloseDetectsUnsyncedRequests(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -3487,7 +3489,7 @@ func TestConnOngaussdbError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	config, err := gaussdbconn.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	config, err := gaussdbconn.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	config.OnGaussdbError = func(c *gaussdbconn.GaussdbConn, gaussdbErr *gaussdbconn.GaussdbError) bool {
 		require.NotNil(t, c)
@@ -3522,7 +3524,7 @@ func TestConnCustomData(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer closeConn(t, gaussdbConn)
 
@@ -3536,7 +3538,7 @@ func Example() {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	gaussdbConn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -3560,7 +3562,7 @@ func Example() {
 }
 
 func GetSSLPassword(ctx context.Context) string {
-	connString := os.Getenv("PGX_SSL_PASSWORD")
+	connString := os.Getenv(gaussdbgo.EnvGaussdbSslPassword)
 	return connString
 }
 
@@ -3832,7 +3834,7 @@ func TestDeadlineContextWatcherHandler(t *testing.T) {
 	t.Parallel()
 
 	t.Run("DeadlineExceeded with zero DeadlineDelay", func(t *testing.T) {
-		config, err := gaussdbconn.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+		config, err := gaussdbconn.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 		require.NoError(t, err)
 		config.BuildContextWatcherHandler = func(conn *gaussdbconn.GaussdbConn) ctxwatch.Handler {
 			return &gaussdbconn.DeadlineContextWatcherHandler{Conn: conn.Conn()}
@@ -3853,7 +3855,7 @@ func TestDeadlineContextWatcherHandler(t *testing.T) {
 	})
 
 	t.Run("DeadlineExceeded with DeadlineDelay", func(t *testing.T) {
-		config, err := gaussdbconn.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+		config, err := gaussdbconn.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 		require.NoError(t, err)
 		config.BuildContextWatcherHandler = func(conn *gaussdbconn.GaussdbConn) ctxwatch.Handler {
 			return &gaussdbconn.DeadlineContextWatcherHandler{Conn: conn.Conn(), DeadlineDelay: 500 * time.Millisecond}
@@ -3878,7 +3880,7 @@ func TestCancelRequestContextWatcherHandler(t *testing.T) {
 	t.Parallel()
 
 	t.Run("DeadlineExceeded cancels request after CancelRequestDelay", func(t *testing.T) {
-		config, err := gaussdbconn.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+		config, err := gaussdbconn.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 		require.NoError(t, err)
 		config.BuildContextWatcherHandler = func(conn *gaussdbconn.GaussdbConn) ctxwatch.Handler {
 			return &gaussdbconn.CancelRequestContextWatcherHandler{
@@ -3905,7 +3907,7 @@ func TestCancelRequestContextWatcherHandler(t *testing.T) {
 	})
 
 	t.Run("DeadlineExceeded - do not send cancel request when query finishes in grace period", func(t *testing.T) {
-		config, err := gaussdbconn.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+		config, err := gaussdbconn.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 		require.NoError(t, err)
 		config.BuildContextWatcherHandler = func(conn *gaussdbconn.GaussdbConn) ctxwatch.Handler {
 			return &gaussdbconn.CancelRequestContextWatcherHandler{
@@ -3930,7 +3932,7 @@ func TestCancelRequestContextWatcherHandler(t *testing.T) {
 	})
 
 	t.Run("DeadlineExceeded sets conn deadline with DeadlineDelay", func(t *testing.T) {
-		config, err := gaussdbconn.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+		config, err := gaussdbconn.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 		require.NoError(t, err)
 		config.BuildContextWatcherHandler = func(conn *gaussdbconn.GaussdbConn) ctxwatch.Handler {
 			return &gaussdbconn.CancelRequestContextWatcherHandler{
@@ -3958,7 +3960,7 @@ func TestCancelRequestContextWatcherHandler(t *testing.T) {
 		t.Run(fmt.Sprintf("Stress %d", i), func(t *testing.T) {
 			t.Parallel()
 
-			config, err := gaussdbconn.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+			config, err := gaussdbconn.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 			require.NoError(t, err)
 			config.BuildContextWatcherHandler = func(conn *gaussdbconn.GaussdbConn) ctxwatch.Handler {
 				return &gaussdbconn.CancelRequestContextWatcherHandler{

--- a/gaussdbconn/gaussdbconn_test.go
+++ b/gaussdbconn/gaussdbconn_test.go
@@ -345,8 +345,8 @@ func TestConnectTimeoutStuckOnTLSHandshake(t *testing.T) {
 
 func TestConnectInvalidUser(t *testing.T) {
 	t.Parallel()
-	if os.Getenv(gaussdbgo.EnvIsOpengauss) == "true" {
-		t.Skip("skip opengauss, use different protocol")
+	if gaussdbgo.IsTestingWithOpengauss() {
+		t.Skip("skip opengauss, different versions of the protocol were used, this error will not occur.")
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()

--- a/gaussdbproto/trace_test.go
+++ b/gaussdbproto/trace_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	gaussdbgo "github.com/HuaweiCloudDeveloper/gaussdb-go"
 	"github.com/HuaweiCloudDeveloper/gaussdb-go/gaussdbconn"
 	"github.com/HuaweiCloudDeveloper/gaussdb-go/gaussdbproto"
 	"github.com/stretchr/testify/require"
@@ -18,7 +19,7 @@ func TestTrace(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	conn, err := gaussdbconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	conn, err := gaussdbconn.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer conn.Close(ctx)
 

--- a/gaussdbtype/example_child_records_test.go
+++ b/gaussdbtype/example_child_records_test.go
@@ -24,7 +24,7 @@ func Example_childRecords() {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	conn, err := gaussdbgo.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	conn, err := gaussdbgo.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	if err != nil {
 		fmt.Printf("Unable to establish connection: %v", err)
 		return

--- a/gaussdbtype/example_custom_type_test.go
+++ b/gaussdbtype/example_custom_type_test.go
@@ -40,7 +40,7 @@ func (src *Point) String() string {
 }
 
 func Example_customType() {
-	conn, err := gaussdbgo.Connect(context.Background(), os.Getenv("PGX_TEST_DATABASE"))
+	conn, err := gaussdbgo.Connect(context.Background(), os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	if err != nil {
 		fmt.Printf("Unable to establish connection: %v", err)
 		return

--- a/gaussdbtype/example_json_test.go
+++ b/gaussdbtype/example_json_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func Example_json() {
-	conn, err := gaussdbgo.Connect(context.Background(), os.Getenv("PGX_TEST_DATABASE"))
+	conn, err := gaussdbgo.Connect(context.Background(), os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	if err != nil {
 		fmt.Printf("Unable to establish connection: %v", err)
 		return

--- a/gaussdbtype/gaussdbtype_test.go
+++ b/gaussdbtype/gaussdbtype_test.go
@@ -25,7 +25,7 @@ var defaultConnTestRunner gaussdbxtest.ConnTestRunner
 func init() {
 	defaultConnTestRunner = gaussdbxtest.DefaultConnTestRunner()
 	defaultConnTestRunner.CreateConfig = func(ctx context.Context, t testing.TB) *gaussdbgo.ConnConfig {
-		config, err := gaussdbgo.ParseConfig(os.Getenv("GAUSSDB_TEST_DATABASE"))
+		config, err := gaussdbgo.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 		require.NoError(t, err)
 		return config
 	}

--- a/gaussdbtype/gaussdbtype_test.go
+++ b/gaussdbtype/gaussdbtype_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
 	"reflect"
 	"testing"
 
@@ -24,8 +25,7 @@ var defaultConnTestRunner gaussdbxtest.ConnTestRunner
 func init() {
 	defaultConnTestRunner = gaussdbxtest.DefaultConnTestRunner()
 	defaultConnTestRunner.CreateConfig = func(ctx context.Context, t testing.TB) *gaussdbgo.ConnConfig {
-		//config, err := gaussdbgo.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
-		config, err := gaussdbgo.ParseConfig("host=1.95.160.45 database=pgx_test user=pgx_md5 password=Gaussdb@123! sslmode=verify-ca sslrootcert=/root/daocloud/gaussdb-go/mine/ca.pem")
+		config, err := gaussdbgo.ParseConfig(os.Getenv("GAUSSDB_TEST_DATABASE"))
 		require.NoError(t, err)
 		return config
 	}

--- a/gaussdbtype/hstore.go
+++ b/gaussdbtype/hstore.go
@@ -122,7 +122,7 @@ func (encodePlanHstoreCodecText) Encode(value any, buf []byte) (newBuf []byte, e
 	}
 
 	if len(hstore) == 0 {
-		// distinguish between empty and nil: Not strictly required by Postgres, since its protocol
+		// distinguish between empty and nil: Not strictly required by Gaussdb, since its protocol
 		// explicitly marks NULL column values separately. However, the Binary codec does this, and
 		// this means we can "round trip" Encode and Scan without data loss.
 		// nil: []byte(nil); empty: []byte{}

--- a/gaussdbtype/hstore_test.go
+++ b/gaussdbtype/hstore_test.go
@@ -131,7 +131,7 @@ func TestHstoreCodec(t *testing.T) {
 		"form\\ffeed",
 		"carriage\rreturn",
 		"curly{}braces",
-		// Postgres on Mac OS X hstore parsing bug:
+		// Gaussdb on Mac OS X hstore parsing bug:
 		// ą = "\xc4\x85" in UTF-8; isspace(0x85) on Mac OS X returns true instead of false
 		"mac_bugą",
 	}

--- a/gaussdbtype/text_test.go
+++ b/gaussdbtype/text_test.go
@@ -94,12 +94,15 @@ func TestTextCodecBPChar(t *testing.T) {
 func TestTextCodecACLItem(t *testing.T) {
 	ctr := defaultConnTestRunner
 	ctr.AfterConnect = func(ctx context.Context, t testing.TB, conn *gaussdbx.Conn) {}
-
+	str := "root=arwdDxt/root"
+	if gaussdbx.IsTestingWithOpengauss() {
+		str = "gaussdb=arwdDxt/gaussdb"
+	}
 	gaussdbxtest.RunValueRoundTripTests(context.Background(), t, ctr, nil, "aclitem", []gaussdbxtest.ValueRoundTripTest{
 		{
-			gaussdbtype.Text{String: "root=arwdDxt/root", Valid: true},
+			gaussdbtype.Text{String: str, Valid: true},
 			new(gaussdbtype.Text),
-			isExpectedEq(gaussdbtype.Text{String: "root=arwdDxt/root", Valid: true}),
+			isExpectedEq(gaussdbtype.Text{String: str, Valid: true}),
 		},
 		{gaussdbtype.Text{}, new(gaussdbtype.Text), isExpectedEq(gaussdbtype.Text{})},
 		{nil, new(gaussdbtype.Text), isExpectedEq(gaussdbtype.Text{})},

--- a/gaussdbtype/xml_test.go
+++ b/gaussdbtype/xml_test.go
@@ -97,6 +97,9 @@ func TestXMLCodecPointerToPointerToString(t *testing.T) {
 }
 
 func TestXMLCodecDecodeValue(t *testing.T) {
+	if gaussdbx.IsTestingWithOpengauss() {
+		t.Skip("skip opengauss,unsupported XML feature (SQLSTATE 0A000)")
+	}
 	defaultConnTestRunner.RunTest(context.Background(), t, func(ctx context.Context, _ testing.TB, conn *gaussdbx.Conn) {
 		for _, tt := range []struct {
 			sql      string

--- a/gaussdbtype/zeronull/zeronull_test.go
+++ b/gaussdbtype/zeronull/zeronull_test.go
@@ -16,7 +16,7 @@ var defaultConnTestRunner gaussdbxtest.ConnTestRunner
 func init() {
 	defaultConnTestRunner = gaussdbxtest.DefaultConnTestRunner()
 	defaultConnTestRunner.CreateConfig = func(ctx context.Context, t testing.TB) *gaussdbgo.ConnConfig {
-		config, err := gaussdbgo.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+		config, err := gaussdbgo.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 		require.NoError(t, err)
 		return config
 	}

--- a/gaussdbxpool/bench_test.go
+++ b/gaussdbxpool/bench_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func BenchmarkAcquireAndRelease(b *testing.B) {
-	pool, err := gaussdbxpool.New(context.Background(), os.Getenv("PGX_TEST_DATABASE"))
+	pool, err := gaussdbxpool.New(context.Background(), os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(b, err)
 	defer pool.Close()
 
@@ -26,7 +26,7 @@ func BenchmarkAcquireAndRelease(b *testing.B) {
 }
 
 func BenchmarkMinimalPreparedSelectBaseline(b *testing.B) {
-	config, err := gaussdbxpool.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	config, err := gaussdbxpool.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(b, err)
 
 	config.AfterConnect = func(ctx context.Context, c *gaussdbgo.Conn) error {
@@ -57,7 +57,7 @@ func BenchmarkMinimalPreparedSelectBaseline(b *testing.B) {
 }
 
 func BenchmarkMinimalPreparedSelect(b *testing.B) {
-	config, err := gaussdbxpool.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	config, err := gaussdbxpool.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(b, err)
 
 	config.AfterConnect = func(ctx context.Context, c *gaussdbgo.Conn) error {

--- a/gaussdbxpool/conn_test.go
+++ b/gaussdbxpool/conn_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	gaussdbgo "github.com/HuaweiCloudDeveloper/gaussdb-go"
 	"github.com/HuaweiCloudDeveloper/gaussdb-go/gaussdbxpool"
 	"github.com/stretchr/testify/require"
 )
@@ -16,7 +17,7 @@ func TestConnExec(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	pool, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	pool, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer pool.Close()
 
@@ -33,7 +34,7 @@ func TestConnQuery(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	pool, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	pool, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer pool.Close()
 
@@ -50,7 +51,7 @@ func TestConnQueryRow(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	pool, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	pool, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer pool.Close()
 
@@ -67,7 +68,7 @@ func TestConnSendBatch(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	pool, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	pool, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer pool.Close()
 
@@ -84,7 +85,7 @@ func TestConnCopyFrom(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	pool, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	pool, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer pool.Close()
 

--- a/gaussdbxpool/pool_test.go
+++ b/gaussdbxpool/pool_test.go
@@ -19,7 +19,7 @@ func TestConnect(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
-	connString := os.Getenv("PGX_TEST_DATABASE")
+	connString := os.Getenv(gaussdbgo.EnvGaussdbTestDatabase)
 	pool, err := gaussdbxpool.New(ctx, connString)
 	require.NoError(t, err)
 	assert.Equal(t, connString, pool.Config().ConnString())
@@ -30,7 +30,7 @@ func TestConnectConfig(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
-	connString := os.Getenv("PGX_TEST_DATABASE")
+	connString := os.Getenv(gaussdbgo.EnvGaussdbTestDatabase)
 	config, err := gaussdbxpool.ParseConfig(connString)
 	require.NoError(t, err)
 	pool, err := gaussdbxpool.NewWithConfig(ctx, config)
@@ -53,7 +53,7 @@ func TestParseConfigExtractsPoolArguments(t *testing.T) {
 func TestConstructorIgnoresContext(t *testing.T) {
 	t.Parallel()
 
-	config, err := gaussdbxpool.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	config, err := gaussdbxpool.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	assert.NoError(t, err)
 	var cancel func()
 	config.BeforeConnect = func(context.Context, *gaussdbgo.ConnConfig) error {
@@ -95,7 +95,7 @@ func TestConfigCopyReturnsEqualConfig(t *testing.T) {
 }
 
 func TestConfigCopyCanBeUsedToConnect(t *testing.T) {
-	connString := os.Getenv("PGX_TEST_DATABASE")
+	connString := os.Getenv(gaussdbgo.EnvGaussdbTestDatabase)
 	original, err := gaussdbxpool.ParseConfig(connString)
 	require.NoError(t, err)
 
@@ -112,7 +112,7 @@ func TestPoolAcquireAndConnRelease(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	pool, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	pool, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer pool.Close()
 
@@ -127,7 +127,7 @@ func TestPoolAcquireAndConnHijack(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	pool, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	pool, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer pool.Close()
 
@@ -155,11 +155,11 @@ func TestPoolAcquireAndConnHijack(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	controllerConn, err := gaussdbgo.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	controllerConn, err := gaussdbgo.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer controllerConn.Close(ctx)
 
-	pool, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	pool, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer pool.Close()
 
@@ -208,7 +208,7 @@ func TestPoolAcquireFunc(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	pool, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	pool, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer pool.Close()
 
@@ -226,7 +226,7 @@ func TestPoolAcquireFuncReturnsFnError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	pool, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	pool, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer pool.Close()
 
@@ -242,7 +242,7 @@ func TestPoolBeforeConnect(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	config, err := gaussdbxpool.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	config, err := gaussdbxpool.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 
 	config.BeforeConnect = func(ctx context.Context, cfg *gaussdbgo.ConnConfig) error {
@@ -266,7 +266,7 @@ func TestPoolAfterConnect(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	config, err := gaussdbxpool.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	config, err := gaussdbxpool.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 
 	config.AfterConnect = func(ctx context.Context, c *gaussdbgo.Conn) error {
@@ -290,7 +290,7 @@ func TestPoolBeforeAcquire(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	config, err := gaussdbxpool.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	config, err := gaussdbxpool.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 
 	acquireAttempts := 0
@@ -335,12 +335,12 @@ func TestPoolAfterRelease(t *testing.T) {
 	defer cancel()
 
 	func() {
-		pool, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+		pool, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 		require.NoError(t, err)
 		defer pool.Close()
 	}()
 
-	config, err := gaussdbxpool.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	config, err := gaussdbxpool.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 
 	afterReleaseCount := 0
@@ -376,12 +376,12 @@ func TestPoolBeforeClose(t *testing.T) {
 	defer cancel()
 
 	func() {
-		pool, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+		pool, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 		require.NoError(t, err)
 		defer pool.Close()
 	}()
 
-	config, err := gaussdbxpool.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	config, err := gaussdbxpool.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 
 	connPIDs := make(chan uint32, 5)
@@ -413,7 +413,7 @@ func TestPoolAcquireAllIdle(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	db, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	db, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -444,7 +444,7 @@ func TestPoolReset(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	db, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	db, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -472,7 +472,7 @@ func TestConnReleaseChecksMaxConnLifetime(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	config, err := gaussdbxpool.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	config, err := gaussdbxpool.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 
 	config.MaxConnLifetime = 250 * time.Millisecond
@@ -499,7 +499,7 @@ func TestConnReleaseClosesBusyConn(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	db, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	db, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -530,7 +530,7 @@ func TestPoolBackgroundChecksMaxConnLifetime(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	config, err := gaussdbxpool.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	config, err := gaussdbxpool.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 
 	config.MaxConnLifetime = 100 * time.Millisecond
@@ -558,7 +558,7 @@ func TestPoolBackgroundChecksMaxConnIdleTime(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	config, err := gaussdbxpool.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	config, err := gaussdbxpool.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 
 	config.MaxConnLifetime = 1 * time.Minute
@@ -594,7 +594,7 @@ func TestPoolBackgroundChecksMinConns(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	config, err := gaussdbxpool.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	config, err := gaussdbxpool.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 
 	config.HealthCheckPeriod = 100 * time.Millisecond
@@ -641,7 +641,7 @@ func TestPoolExec(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	pool, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	pool, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer pool.Close()
 
@@ -654,7 +654,7 @@ func TestPoolQuery(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	pool, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	pool, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer pool.Close()
 
@@ -686,7 +686,7 @@ func TestPoolQueryRow(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	pool, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	pool, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer pool.Close()
 
@@ -704,7 +704,7 @@ func TestPoolQueryRowErrNoRows(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	pool, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	pool, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer pool.Close()
 
@@ -718,7 +718,7 @@ func TestPoolQueryRowScanPanicReleasesConnection(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	pool, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	pool, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer pool.Close()
 
@@ -736,7 +736,7 @@ func TestPoolSendBatch(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	pool, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	pool, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer pool.Close()
 
@@ -756,7 +756,7 @@ func TestPoolCopyFrom(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	pool, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	pool, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer pool.Close()
 
@@ -800,7 +800,7 @@ func TestConnReleaseClosesConnInFailedTransaction(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	pool, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	pool, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer pool.Close()
 
@@ -839,7 +839,7 @@ func TestConnReleaseClosesConnInTransaction(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	pool, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	pool, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer pool.Close()
 
@@ -873,7 +873,7 @@ func TestConnReleaseDestroysClosedConn(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	pool, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	pool, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer pool.Close()
 
@@ -905,7 +905,7 @@ func TestConnPoolQueryConcurrentLoad(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	pool, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	pool, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer pool.Close()
 
@@ -931,7 +931,7 @@ func TestConnReleaseWhenBeginFail(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	db, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	db, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -958,7 +958,7 @@ func TestTxBeginFuncNestedTransactionCommit(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	db, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	db, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -1008,7 +1008,7 @@ func TestTxBeginFuncNestedTransactionRollback(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	db, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	db, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -1055,7 +1055,7 @@ func TestIdempotentPoolClose(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	pool, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	pool, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 
 	// Close the open pool.
@@ -1071,7 +1071,7 @@ func TestConnectEagerlyReachesMinPoolSize(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	config, err := gaussdbxpool.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	config, err := gaussdbxpool.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 
 	config.MinConns = int32(12)
@@ -1112,7 +1112,7 @@ func TestPoolSendBatchBatchCloseTwice(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	pool, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	pool, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer pool.Close()
 

--- a/gaussdbxpool/pool_test.go
+++ b/gaussdbxpool/pool_test.go
@@ -835,7 +835,9 @@ func TestConnReleaseClosesConnInFailedTransaction(t *testing.T) {
 
 func TestConnReleaseClosesConnInTransaction(t *testing.T) {
 	t.Parallel()
-
+	if gaussdbgo.IsTestingWithOpengauss() {
+		t.Skip("skip opengauss, the pid not changed")
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 

--- a/gaussdbxpool/tracer_test.go
+++ b/gaussdbxpool/tracer_test.go
@@ -53,7 +53,7 @@ func TestTraceAcquire(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	config, err := gaussdbxpool.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	config, err := gaussdbxpool.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	config.ConnConfig.Tracer = tracer
 
@@ -108,7 +108,7 @@ func TestTraceRelease(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	config, err := gaussdbxpool.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	config, err := gaussdbxpool.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	config.ConnConfig.Tracer = tracer
 

--- a/gaussdbxpool/tx_test.go
+++ b/gaussdbxpool/tx_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	gaussdbgo "github.com/HuaweiCloudDeveloper/gaussdb-go"
 	"github.com/HuaweiCloudDeveloper/gaussdb-go/gaussdbxpool"
 	"github.com/stretchr/testify/require"
 )
@@ -16,7 +17,7 @@ func TestTxExec(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	pool, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	pool, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer pool.Close()
 
@@ -33,7 +34,7 @@ func TestTxQuery(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	pool, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	pool, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer pool.Close()
 
@@ -50,7 +51,7 @@ func TestTxQueryRow(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	pool, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	pool, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer pool.Close()
 
@@ -67,7 +68,7 @@ func TestTxSendBatch(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	pool, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	pool, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer pool.Close()
 
@@ -84,7 +85,7 @@ func TestTxCopyFrom(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	pool, err := gaussdbxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	pool, err := gaussdbxpool.New(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	defer pool.Close()
 

--- a/helper_test.go
+++ b/helper_test.go
@@ -19,7 +19,7 @@ var defaultConnTestRunner gaussdbxtest.ConnTestRunner
 func init() {
 	defaultConnTestRunner = gaussdbxtest.DefaultConnTestRunner()
 	defaultConnTestRunner.CreateConfig = func(ctx context.Context, t testing.TB) *gaussdbgo.ConnConfig {
-		config, err := gaussdbgo.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+		config, err := gaussdbgo.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 		require.NoError(t, err)
 		return config
 	}
@@ -139,7 +139,7 @@ func assertConfigsEqual(t *testing.T, expected, actual *gaussdbgo.ConnConfig, te
 }
 
 func lowerFirstLetterInError(s string) string {
-	if os.Getenv("IS_OPENGAUSS") != "true" || s == "" || strings.HasPrefix(s, "SQLSTATE") {
+	if os.Getenv(gaussdbgo.EnvIsOpengauss) != "true" || s == "" || strings.HasPrefix(s, "SQLSTATE") {
 		return s
 	}
 	prefix := ""

--- a/helper_test.go
+++ b/helper_test.go
@@ -3,6 +3,7 @@ package gaussdbgo_test
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -135,4 +136,17 @@ func assertConfigsEqual(t *testing.T, expected, actual *gaussdbgo.ConnConfig, te
 			}
 		}
 	}
+}
+
+func lowerFirstLetterInError(s string) string {
+	if os.Getenv("IS_OPENGAUSS") != "true" || s == "" || strings.HasPrefix(s, "SQLSTATE") {
+		return s
+	}
+	prefix := ""
+	leftOver := s
+	if strings.HasPrefix(s, "ERROR: ") {
+		prefix = "ERROR: "
+		leftOver = strings.TrimPrefix(s, prefix)
+	}
+	return prefix + strings.ToLower(leftOver[:1]) + leftOver[1:]
 }

--- a/helper_test.go
+++ b/helper_test.go
@@ -139,7 +139,7 @@ func assertConfigsEqual(t *testing.T, expected, actual *gaussdbgo.ConnConfig, te
 }
 
 func lowerFirstLetterInError(s string) string {
-	if os.Getenv(gaussdbgo.EnvIsOpengauss) != "true" || s == "" || strings.HasPrefix(s, "SQLSTATE") {
+	if !gaussdbgo.IsTestingWithOpengauss() || s == "" || strings.HasPrefix(s, "SQLSTATE") {
 		return s
 	}
 	prefix := ""

--- a/large_objects_test.go
+++ b/large_objects_test.go
@@ -9,7 +9,7 @@ package gaussdbgo_test
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	conn, err := gaussdbgo.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	conn, err := gaussdbgo.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +29,7 @@ package gaussdbgo_test
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	config, err := gaussdbgo.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	config, err := gaussdbgo.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -155,7 +155,7 @@ package gaussdbgo_test
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	conn, err := gaussdbgo.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	conn, err := gaussdbgo.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pgbouncer_test.go
+++ b/pgbouncer_test.go
@@ -5,15 +5,15 @@ import (
 	"os"
 	"testing"
 
-	"github.com/HuaweiCloudDeveloper/gaussdb-go"
+	gaussdbgo "github.com/HuaweiCloudDeveloper/gaussdb-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPgbouncerStatementCacheDescribe(t *testing.T) {
-	connString := os.Getenv("PGX_TEST_PGBOUNCER_CONN_STRING")
+	connString := os.Getenv(gaussdbgo.EnvGaussdbTestPgbouncerConnString)
 	if connString == "" {
-		t.Skipf("Skipping due to missing environment variable %v", "PGX_TEST_PGBOUNCER_CONN_STRING")
+		t.Skipf("Skipping due to missing environment variable %v", gaussdbgo.EnvGaussdbTestPgbouncerConnString)
 	}
 
 	config := mustParseConfig(t, connString)
@@ -24,9 +24,9 @@ func TestPgbouncerStatementCacheDescribe(t *testing.T) {
 }
 
 func TestPgbouncerSimpleProtocol(t *testing.T) {
-	connString := os.Getenv("PGX_TEST_PGBOUNCER_CONN_STRING")
+	connString := os.Getenv(gaussdbgo.EnvGaussdbTestPgbouncerConnString)
 	if connString == "" {
-		t.Skipf("Skipping due to missing environment variable %v", "PGX_TEST_PGBOUNCER_CONN_STRING")
+		t.Skipf("Skipping due to missing environment variable %v", gaussdbgo.EnvGaussdbTestPgbouncerConnString)
 	}
 
 	config := mustParseConfig(t, connString)

--- a/query_test.go
+++ b/query_test.go
@@ -1488,8 +1488,7 @@ func TestQueryContextErrorWhileReceivingRows(t *testing.T) {
 		rowCount++
 	}
 	// opengauss return 'ERROR: division by zero (SQLSTATE 22012)', gaussdb return 'ERROR: Division by zero. (SQLSTATE 22012)'
-	errStr := lowerFirstLetterInError("ERROR: Division by zero (SQLSTATE 22012)")
-	if rows.Err() == nil || rows.Err().Error() != errStr {
+	if rows.Err() == nil || !strings.Contains(rows.Err().Error(), "SQLSTATE 22012") {
 		t.Fatalf("Expected division by zero error, but got %v", rows.Err())
 	}
 
@@ -1536,7 +1535,7 @@ func TestQueryRowContextErrorWhileReceivingRow(t *testing.T) {
 	var result int
 	err := conn.QueryRow(ctx, "select 10/0").Scan(&result)
 	// opengauss return 'ERROR: division by zero (SQLSTATE 22012)', gaussdb return 'ERROR: Division by zero. (SQLSTATE 22012)'
-	if err == nil || err.Error() != lowerFirstLetterInError("ERROR: Division by zero (SQLSTATE 22012)") {
+	if err == nil || !strings.Contains(err.Error(), "SQLSTATE 22012") {
 		t.Fatalf("Expected division by zero error, but got %v", err)
 	}
 

--- a/query_test.go
+++ b/query_test.go
@@ -25,7 +25,7 @@ import (
 func TestConnQueryScan(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	var sum, rowCount int32
@@ -60,7 +60,7 @@ func TestConnQueryScan(t *testing.T) {
 func TestConnQueryRowsFieldDescriptionsBeforeNext(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	rows, err := conn.Query(context.Background(), "select 'hello' as msg")
@@ -75,7 +75,7 @@ func TestConnQueryRowsFieldDescriptionsBeforeNext(t *testing.T) {
 /*func TestConnQueryWithoutResultSetCommandTag(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	rows, err := conn.Query(context.Background(), "create temporary table t (id serial);")
@@ -88,7 +88,7 @@ func TestConnQueryRowsFieldDescriptionsBeforeNext(t *testing.T) {
 func TestConnQueryScanWithManyColumns(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	columnCount := 1000
@@ -140,7 +140,7 @@ func TestConnQueryScanWithManyColumns(t *testing.T) {
 func TestConnQueryValues(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	var rowCount int32
@@ -176,7 +176,7 @@ func TestConnQueryValues(t *testing.T) {
 func TestConnQueryValuesWhenUnableToDecode(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	// Note that this relies on gaussdbtype.Record not supporting the text protocol. This seems safe as it is impossible to
@@ -198,7 +198,7 @@ func TestConnQueryValuesWithUnregisteredOID(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	tx, err := conn.Begin(ctx)
@@ -243,7 +243,7 @@ func TestConnQueryArgsAndScanWithUnregisteredOID(t *testing.T) {
 func TestConnQueryReadRowMultipleTimes(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	var rowCount int32
@@ -287,7 +287,7 @@ func TestConnQueryReadRowMultipleTimes(t *testing.T) {
 func TestRowsScanDoesNotAllowScanningBinaryFormatValuesIntoString(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	var s string
@@ -303,7 +303,7 @@ func TestRowsScanDoesNotAllowScanningBinaryFormatValuesIntoString(t *testing.T) 
 func TestConnQueryRawValues(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	var rowCount int32
@@ -337,7 +337,7 @@ func TestConnQueryRawValues(t *testing.T) {
 func TestConnQueryCloseEarly(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	// Immediately close query without reading any rows
@@ -374,7 +374,7 @@ func TestConnQueryCloseEarly(t *testing.T) {
 func TestConnQueryCloseEarlyWithErrorOnWire(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	rows, err := conn.Query(context.Background(), "select 1/(10-n) from generate_series(1,10) n")
@@ -391,7 +391,7 @@ func TestConnQueryCloseEarlyWithErrorOnWire(t *testing.T) {
 func TestConnQueryReadWrongTypeError(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	// Read a single value incorrectly
@@ -427,7 +427,7 @@ func TestConnQueryReadWrongTypeError(t *testing.T) {
 func TestConnQueryReadTooManyValues(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	// Read too many values
@@ -458,7 +458,7 @@ func TestConnQueryReadTooManyValues(t *testing.T) {
 func TestConnQueryScanIgnoreColumn(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	rows, err := conn.Query(context.Background(), "select 1::int8, 2::int8, 3::int8")
@@ -492,7 +492,7 @@ func TestConnQueryScanIgnoreColumn(t *testing.T) {
 func TestConnQueryDeferredError(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	mustExec(t, conn, `create temporary table t (
@@ -532,7 +532,7 @@ insert into t (id, n) values ('a', 1), ('b', 2), ('c', 3);`)
 func TestConnQueryErrorWhileReturningRows(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	for i := 0; i < 100; i++ {
@@ -566,7 +566,7 @@ func TestConnQueryErrorWhileReturningRows(t *testing.T) {
 func TestQueryEncodeError(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	rows, err := conn.Query(context.Background(), "select $1::integer", "wrong")
@@ -589,7 +589,7 @@ func TestQueryEncodeError(t *testing.T) {
 func TestQueryRowCoreTypes(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	type allTypes struct {
@@ -646,7 +646,7 @@ func TestQueryRowCoreTypes(t *testing.T) {
 func TestQueryRowCoreIntegerEncoding(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	type allTypes struct {
@@ -754,7 +754,7 @@ func TestQueryRowCoreIntegerEncoding(t *testing.T) {
 func TestQueryRowCoreIntegerDecoding(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	type allTypes struct {
@@ -928,7 +928,7 @@ func TestQueryRowCoreIntegerDecoding(t *testing.T) {
 func TestQueryRowCoreByteSlice(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	tests := []struct {
@@ -961,7 +961,7 @@ func TestQueryRowCoreByteSlice(t *testing.T) {
 func TestQueryRowErrors(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	type allTypes struct {
@@ -1002,7 +1002,7 @@ func TestQueryRowErrors(t *testing.T) {
 func TestQueryRowNoResults(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	var n int32
@@ -1017,7 +1017,7 @@ func TestQueryRowNoResults(t *testing.T) {
 func TestQueryRowEmptyQuery(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
@@ -1032,7 +1032,7 @@ func TestQueryRowEmptyQuery(t *testing.T) {
 }
 
 func TestReadingValueAfterEmptyArray(t *testing.T) {
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	var a []string
@@ -1052,7 +1052,7 @@ func TestReadingValueAfterEmptyArray(t *testing.T) {
 }
 
 func TestReadingNullByteArray(t *testing.T) {
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	var a []byte
@@ -1067,7 +1067,7 @@ func TestReadingNullByteArray(t *testing.T) {
 }
 
 func TestReadingNullByteArrays(t *testing.T) {
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	rows, err := conn.Query(context.Background(), "select null::text union all select null::text")
@@ -1092,7 +1092,7 @@ func TestReadingNullByteArrays(t *testing.T) {
 }
 
 func TestQueryNullSliceIsSet(t *testing.T) {
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	a := []int32{1, 2, 3}
@@ -1109,7 +1109,7 @@ func TestQueryNullSliceIsSet(t *testing.T) {
 func TestConnQueryDatabaseSQLScanner(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	var num sql.NullFloat64
@@ -1128,7 +1128,7 @@ func TestConnQueryDatabaseSQLScanner(t *testing.T) {
 func TestConnQueryDatabaseSQLDriverValuer(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	expected := sql.NullFloat64{Float64: 1234.567, Valid: true}
@@ -1144,7 +1144,7 @@ func TestConnQueryDatabaseSQLDriverValuer(t *testing.T) {
 func TestConnQueryDatabaseSQLDriverValuerWithAutoGeneratedPointerReceiver(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	mustExec(t, conn, "create temporary table t(n numeric)")
@@ -1177,7 +1177,7 @@ func (v *nilPointerAsEmptyJSONObject) Value() (driver.Value, error) {
 func TestConnQueryDatabaseSQLDriverValuerCalledOnNilPointerImplementers(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	mustExec(t, conn, "create temporary table t(v json not null)")
@@ -1226,7 +1226,7 @@ func (j *nilSliceAsEmptySlice) UnmarshalJSON(data []byte) error {
 func TestConnQueryDatabaseSQLDriverValuerCalledOnNilSliceImplementers(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	mustExec(t, conn, "create temporary table t(v json not null)")
@@ -1282,7 +1282,7 @@ func (j *nilMapAsEmptyObject) UnmarshalJSON(data []byte) error {
 func TestConnQueryDatabaseSQLDriverValuerCalledOnNilMapImplementers(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	mustExec(t, conn, "create temporary table t(v json not null)")
@@ -1316,7 +1316,7 @@ func TestConnQueryDatabaseSQLDriverValuerCalledOnNilMapImplementers(t *testing.T
 func TestConnQueryDatabaseSQLDriverScannerWithBinaryGaussdbTypeThatAcceptsSameType(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	var actual sql.NullString
@@ -1332,7 +1332,7 @@ func TestConnQueryDatabaseSQLDriverScannerWithBinaryGaussdbTypeThatAcceptsSameTy
 func TestConnQueryDatabaseSQLDriverValuerTextWhenBinaryIsPreferred(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	arg := sql.NullString{String: "1.234", Valid: true}
@@ -1351,7 +1351,7 @@ func TestConnQueryDatabaseSQLDriverValuerTextWhenBinaryIsPreferred(t *testing.T)
 func TestConnQueryDatabaseSQLNullFloat64NegativeZeroPointZero(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	tests := []float64{
@@ -1373,7 +1373,7 @@ func TestConnQueryDatabaseSQLNullFloat64NegativeZeroPointZero(t *testing.T) {
 func TestConnQueryDatabaseSQLNullX(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	type row struct {
@@ -1431,7 +1431,7 @@ func TestConnQueryDatabaseSQLNullX(t *testing.T) {
 func TestQueryContextSuccess(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
@@ -1468,7 +1468,7 @@ func TestQueryContextSuccess(t *testing.T) {
 func TestQueryContextErrorWhileReceivingRows(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
@@ -1506,7 +1506,7 @@ func TestQueryContextErrorWhileReceivingRows(t *testing.T) {
 func TestQueryRowContextSuccess(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
@@ -1527,7 +1527,7 @@ func TestQueryRowContextSuccess(t *testing.T) {
 func TestQueryRowContextErrorWhileReceivingRow(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
@@ -1546,7 +1546,7 @@ func TestQueryRowContextErrorWhileReceivingRow(t *testing.T) {
 func TestQueryCloseBefore(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	closeConn(t, conn)
 
 	_, err := conn.Query(context.Background(), "select 1")
@@ -1557,7 +1557,7 @@ func TestQueryCloseBefore(t *testing.T) {
 func TestScanRow(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	resultReader := conn.GaussdbConn().ExecParams(context.Background(), "select generate_series(1,$1)", [][]byte{[]byte("10")}, nil, nil, nil)
@@ -1582,7 +1582,7 @@ func TestScanRow(t *testing.T) {
 func TestConnSimpleProtocol(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	// Test all supported low-level types
@@ -1986,7 +1986,7 @@ func TestConnSimpleProtocol(t *testing.T) {
 func TestConnSimpleProtocolRefusesNonUTF8ClientEncoding(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	mustExec(t, conn, "set client_encoding to 'SQL_ASCII'")
@@ -2008,7 +2008,7 @@ func TestConnSimpleProtocolRefusesNonUTF8ClientEncoding(t *testing.T) {
 func TestConnSimpleProtocolRefusesNonStandardConformingStrings(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	mustExec(t, conn, "set standard_conforming_strings to off")
@@ -2030,7 +2030,7 @@ func TestConnSimpleProtocolRefusesNonStandardConformingStrings(t *testing.T) {
 func TestQueryErrorWithDisabledStatementCache(t *testing.T) {
 	t.Parallel()
 
-	config := mustParseConfig(t, os.Getenv("PGX_TEST_DATABASE"))
+	config := mustParseConfig(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	config.DefaultQueryExecMode = gaussdbgo.QueryExecModeDescribeExec
 	config.StatementCacheCapacity = 0
 	config.DescriptionCacheCapacity = 0
@@ -2065,7 +2065,7 @@ func TestConnQueryQueryExecModeCacheDescribeSafeEvenWhenTypesChange(t *testing.T
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	_, err := conn.Exec(ctx, `create temporary table to_change (
@@ -2146,7 +2146,7 @@ func ExampleConn_Query() {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	conn, err := gaussdbgo.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	conn, err := gaussdbgo.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	if err != nil {
 		fmt.Printf("Unable to establish connection: %v", err)
 		return

--- a/query_test.go
+++ b/query_test.go
@@ -977,7 +977,7 @@ func TestQueryRowErrors(t *testing.T) {
 		scanArgs  []any
 		err       string
 	}{
-		// todo: gaussdb: 'ERROR: Type "badtype" does not exist. (SQLSTATE 42704)', opengauss: 'ERROR: type "badtype" does not exist (SQLSTATE 42704)'
+		// gaussdb: 'ERROR: Type "badtype" does not exist. (SQLSTATE 42704)', opengauss: 'ERROR: type "badtype" does not exist (SQLSTATE 42704)'
 		{"select $1::badtype", []any{"Jack"}, []any{&actual.i16}, `Type "badtype" does not exist`},
 		{"SYNTAX ERROR", []any{}, []any{&actual.i16}, "SQLSTATE 42601"},
 		{"select $1::text", []any{"Jack"}, []any{&actual.i16}, "cannot scan text (OID 25) in text format into *int16"},
@@ -991,7 +991,7 @@ func TestQueryRowErrors(t *testing.T) {
 		if err == nil {
 			t.Errorf("%d. Unexpected success (sql -> %v, queryArgs -> %v)", i, tt.sql, tt.queryArgs)
 		}
-		if err != nil && !strings.Contains(err.Error(), tt.err) {
+		if err != nil && !strings.Contains(err.Error(), lowerFirstLetterInError(tt.err)) {
 			t.Errorf("%d. Expected error to contain %s, but got %v (sql -> %v, queryArgs -> %v)", i, tt.err, err, tt.sql, tt.queryArgs)
 		}
 
@@ -1487,8 +1487,9 @@ func TestQueryContextErrorWhileReceivingRows(t *testing.T) {
 		}
 		rowCount++
 	}
-	// todo: opengauss return 'ERROR: division by zero (SQLSTATE 22012)', gaussdb return 'ERROR: Division by zero. (SQLSTATE 22012)'
-	if rows.Err() == nil || rows.Err().Error() != "ERROR: Division by zero. (SQLSTATE 22012)" {
+	// opengauss return 'ERROR: division by zero (SQLSTATE 22012)', gaussdb return 'ERROR: Division by zero. (SQLSTATE 22012)'
+	errStr := lowerFirstLetterInError("ERROR: Division by zero (SQLSTATE 22012)")
+	if rows.Err() == nil || rows.Err().Error() != errStr {
 		t.Fatalf("Expected division by zero error, but got %v", rows.Err())
 	}
 
@@ -1534,8 +1535,8 @@ func TestQueryRowContextErrorWhileReceivingRow(t *testing.T) {
 
 	var result int
 	err := conn.QueryRow(ctx, "select 10/0").Scan(&result)
-	// same as TestQueryContextErrorWhileReceivingRows
-	if err == nil || err.Error() != "ERROR: Division by zero. (SQLSTATE 22012)" {
+	// opengauss return 'ERROR: division by zero (SQLSTATE 22012)', gaussdb return 'ERROR: Division by zero. (SQLSTATE 22012)'
+	if err == nil || err.Error() != lowerFirstLetterInError("ERROR: Division by zero (SQLSTATE 22012)") {
 		t.Fatalf("Expected division by zero error, but got %v", err)
 	}
 

--- a/rows_test.go
+++ b/rows_test.go
@@ -130,7 +130,7 @@ func TestForEachRowAbort(t *testing.T) {
 }
 
 func ExampleForEachRow() {
-	conn, err := gaussdbgo.Connect(context.Background(), os.Getenv("PGX_TEST_DATABASE"))
+	conn, err := gaussdbgo.Connect(context.Background(), os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	if err != nil {
 		fmt.Printf("Unable to establish connection: %v", err)
 		return
@@ -195,7 +195,7 @@ func ExampleCollectRows() {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	conn, err := gaussdbgo.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	conn, err := gaussdbgo.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	if err != nil {
 		fmt.Printf("Unable to establish connection: %v", err)
 		return
@@ -344,7 +344,7 @@ func ExampleRowTo() {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	conn, err := gaussdbgo.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	conn, err := gaussdbgo.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	if err != nil {
 		fmt.Printf("Unable to establish connection: %v", err)
 		return
@@ -380,7 +380,7 @@ func ExampleRowToAddrOf() {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	conn, err := gaussdbgo.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	conn, err := gaussdbgo.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	if err != nil {
 		fmt.Printf("Unable to establish connection: %v", err)
 		return
@@ -557,7 +557,7 @@ func ExampleRowToStructByPos() {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	conn, err := gaussdbgo.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	conn, err := gaussdbgo.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	if err != nil {
 		fmt.Printf("Unable to establish connection: %v", err)
 		return
@@ -733,7 +733,7 @@ func ExampleRowToStructByName() {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	conn, err := gaussdbgo.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	conn, err := gaussdbgo.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	if err != nil {
 		fmt.Printf("Unable to establish connection: %v", err)
 		return
@@ -920,7 +920,7 @@ func ExampleRowToStructByNameLax() {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	conn, err := gaussdbgo.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	conn, err := gaussdbgo.Connect(ctx, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	if err != nil {
 		fmt.Printf("Unable to establish connection: %v", err)
 		return

--- a/stdlib/bench_test.go
+++ b/stdlib/bench_test.go
@@ -20,7 +20,7 @@ func getSelectRowsCounts(b *testing.B) []int64 {
 			for _, p := range strings.Split(s, " ") {
 				n, err := strconv.ParseInt(p, 10, 64)
 				if err != nil {
-					b.Fatalf("Bad GAUSSDB_BENCH_SELECT_ROWS_COUNTS value: %v", err)
+					b.Fatalf("Bad %s value: %v", gaussdbgo.EnvGaussdbBenchSelectRowsCounts, err)
 				}
 				rowCounts = append(rowCounts, n)
 			}

--- a/stdlib/bench_test.go
+++ b/stdlib/bench_test.go
@@ -8,17 +8,19 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	gaussdbgo "github.com/HuaweiCloudDeveloper/gaussdb-go"
 )
 
 func getSelectRowsCounts(b *testing.B) []int64 {
 	var rowCounts []int64
 	{
-		s := os.Getenv("PGX_BENCH_SELECT_ROWS_COUNTS")
+		s := os.Getenv(gaussdbgo.EnvGaussdbBenchSelectRowsCounts)
 		if s != "" {
 			for _, p := range strings.Split(s, " ") {
 				n, err := strconv.ParseInt(p, 10, 64)
 				if err != nil {
-					b.Fatalf("Bad PGX_BENCH_SELECT_ROWS_COUNTS value: %v", err)
+					b.Fatalf("Bad GAUSSDB_BENCH_SELECT_ROWS_COUNTS value: %v", err)
 				}
 				rowCounts = append(rowCounts, n)
 			}

--- a/stdlib/sql_test.go
+++ b/stdlib/sql_test.go
@@ -436,8 +436,8 @@ func TestConnQueryFailure(t *testing.T) {
 }
 
 func TestConnSimpleSlicePassThrough(t *testing.T) {
-	if gaussdbgo.EnvIsOpengauss == "true" {
-		t.Skip("skip opengauss, not 'cardinality' function")
+	if gaussdbgo.IsTestingWithOpengauss() {
+		t.Skip("skip opengauss, no 'cardinality' function")
 	}
 	testWithAllQueryExecModes(t, func(t *testing.T, db *sql.DB) {
 		var n int64

--- a/tracelog/tracelog_test.go
+++ b/tracelog/tracelog_test.go
@@ -24,7 +24,7 @@ var defaultConnTestRunner gaussdbxtest.ConnTestRunner
 func init() {
 	defaultConnTestRunner = gaussdbxtest.DefaultConnTestRunner()
 	defaultConnTestRunner.CreateConfig = func(ctx context.Context, t testing.TB) *gaussdbgo.ConnConfig {
-		config, err := gaussdbgo.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+		config, err := gaussdbgo.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 		require.NoError(t, err)
 		return config
 	}
@@ -483,7 +483,7 @@ func TestConcurrentUsage(t *testing.T) {
 		LogLevel: tracelog.LogLevelTrace,
 	}
 
-	config, err := gaussdbxpool.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	config, err := gaussdbxpool.ParseConfig(os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	require.NoError(t, err)
 	config.ConnConfig.Tracer = tracer
 

--- a/tx_test.go
+++ b/tx_test.go
@@ -16,7 +16,7 @@ import (
 func TestTransactionSuccessfulCommit(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	createSql := `
@@ -58,7 +58,7 @@ func TestTransactionSuccessfulCommit(t *testing.T) {
 func TestTxCommitWhenTxBroken(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	createSql := `
@@ -104,7 +104,7 @@ func TestTxCommitWhenTxBroken(t *testing.T) {
 func TestTxCommitWhenDeferredConstraintFailure(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	createSql := `
@@ -150,14 +150,14 @@ func TestTxCommitWhenDeferredConstraintFailure(t *testing.T) {
 /*func TestTxCommitSerializationFailure(t *testing.T) {
 	t.Parallel()
 
-	c1 := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	c1 := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, c1)
 
 	if c1.GaussdbConn().ParameterStatus("crdb_version") != "" {
 		t.Skip("Skipping due to known server issue: (https://github.com/cockroachdb/cockroach/issues/60754)")
 	}
 
-	c2 := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	c2 := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, c2)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -209,7 +209,7 @@ func TestTxCommitWhenDeferredConstraintFailure(t *testing.T) {
 func TestTransactionSuccessfulRollback(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	createSql := `
@@ -251,7 +251,7 @@ func TestTransactionSuccessfulRollback(t *testing.T) {
 func TestTransactionRollbackFailsClosesConnection(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -270,7 +270,7 @@ func TestTransactionRollbackFailsClosesConnection(t *testing.T) {
 func TestBeginIsoLevels(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	// todo GaussDB目前功能上不支持此隔离级别，等价于REPEATABLE READ (参考：https://support.huaweicloud.com/intl/zh-cn/centralized-devg-v2-gaussdb/gaussdb_42_0501.html)
@@ -297,7 +297,7 @@ func TestBeginIsoLevels(t *testing.T) {
 func TestBeginFunc(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	createSql := `
@@ -326,7 +326,7 @@ func TestBeginFunc(t *testing.T) {
 func TestBeginFuncRollbackOnError(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	createSql := `
@@ -355,7 +355,7 @@ func TestBeginFuncRollbackOnError(t *testing.T) {
 func TestBeginReadOnly(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	tx, err := conn.BeginTx(context.Background(), gaussdbgo.TxOptions{AccessMode: gaussdbgo.ReadOnly})
@@ -393,7 +393,7 @@ func TestBeginTxBeginQuery(t *testing.T) {
 func TestTxNestedTransactionCommit(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	createSql := `
@@ -465,7 +465,7 @@ func TestTxNestedTransactionCommit(t *testing.T) {
 func TestTxNestedTransactionRollback(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	createSql := `
@@ -527,7 +527,7 @@ func TestTxNestedTransactionRollback(t *testing.T) {
 func TestTxBeginFuncNestedTransactionCommit(t *testing.T) {
 	t.Parallel()
 
-	db := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	db := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, db)
 
 	createSql := `
@@ -571,7 +571,7 @@ func TestTxBeginFuncNestedTransactionCommit(t *testing.T) {
 func TestTxBeginFuncNestedTransactionRollback(t *testing.T) {
 	t.Parallel()
 
-	db := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	db := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, db)
 
 	createSql := `
@@ -611,7 +611,7 @@ func TestTxBeginFuncNestedTransactionRollback(t *testing.T) {
 func TestTxSendBatchClosed(t *testing.T) {
 	t.Parallel()
 
-	db := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	db := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, db)
 
 	tx, err := db.Begin(context.Background())

--- a/values_test.go
+++ b/values_test.go
@@ -102,7 +102,7 @@ func TestJSONAndJSONBTranscode(t *testing.T) {
 func TestJSONAndJSONBTranscodeExtendedOnly(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 
 	for _, typename := range []string{"json", "jsonb"} {
@@ -958,7 +958,7 @@ func TestEncodeTypeRename(t *testing.T) {
 // func TestRowDecodeBinary(t *testing.T) {
 // 	t.Parallel()
 
-// 	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+// 	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 // 	defer closeConn(t, conn)
 
 // 	tests := []struct {
@@ -1038,7 +1038,7 @@ order by a nulls first
 func TestScanIntoByteSlice(t *testing.T) {
 	t.Parallel()
 
-	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	conn := mustConnectString(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase))
 	defer closeConn(t, conn)
 	// Success cases
 	for _, tt := range []struct {


### PR DESCRIPTION
1. use the function lowerFirstLetterInError to make the error messages of opengauss and gaussdb compatible
2. remove `PGX_` prefix in test env
3. add `env.go`, replace all literal env to const, add function `IsTestingWithOpengauss`
4. passed all tests in Opengauss and GaussDB
   Opengauss: 
   ![image](https://github.com/user-attachments/assets/49b28cb1-8148-4903-a442-7a66ec74d403)
   GaussDB:
   ![image](https://github.com/user-attachments/assets/ecab20e2-c3ce-4c3d-b6b8-809c03a37d08)
 
