### PR TITLE
remove pgbouncer in test code

### DIFF
--- a/env.go
+++ b/env.go
@@ -8,7 +8,6 @@ const (
 	EnvGaussdbBenchSelectRowsCounts   = "GAUSSDB_BENCH_SELECT_ROWS_COUNTS"
 	EnvGaussdbSslPassword             = "GAUSSDB_SSL_PASSWORD"
 	EnvGaussdbTestCratedbConnString   = "GAUSSDB_TEST_CRATEDB_CONN_STRING"
-	EnvGaussdbTestPgbouncerConnString = "GAUSSDB_TEST_PGBOUNCER_CONN_STRING"
 	EnvGaussdbTestStressFactor        = "GAUSSDB_TEST_STRESS_FACTOR"
 	EnvGaussdbTestTcpConnString       = "GAUSSDB_TEST_TCP_CONN_STRING"
 	EnvGaussdbTestTlsClientConnString = "GAUSSDB_TEST_TLS_CLIENT_CONN_STRING"

--- a/gaussdbconn/gaussdbconn_test.go
+++ b/gaussdbconn/gaussdbconn_test.go
@@ -29,9 +29,6 @@ import (
 	"github.com/HuaweiCloudDeveloper/gaussdb-go/internal/gaussdbmock"
 )
 
-// TODO: remove pgbouncer?
-const pgbouncerConnStringEnvVar = gaussdbgo.EnvGaussdbTestPgbouncerConnString
-
 func TestConnect(t *testing.T) {
 	tests := []struct {
 		name string
@@ -2348,17 +2345,6 @@ func TestConnContextCanceledCancelsRunningQueryOnServer(t *testing.T) {
 		t.Parallel()
 
 		testConnContextCanceledCancelsRunningQueryOnServer(t, os.Getenv(gaussdbgo.EnvGaussdbTestDatabase), "postgres")
-	})
-
-	t.Run("pgbouncer", func(t *testing.T) {
-		t.Parallel()
-
-		connString := os.Getenv(pgbouncerConnStringEnvVar)
-		if connString == "" {
-			t.Skipf("Skipping due to missing environment variable %v", pgbouncerConnStringEnvVar)
-		}
-
-		testConnContextCanceledCancelsRunningQueryOnServer(t, connString, "pgbouncer")
 	})
 }
 

--- a/pgbouncer_test.go
+++ b/pgbouncer_test.go
@@ -2,38 +2,12 @@ package gaussdbgo_test
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	gaussdbgo "github.com/HuaweiCloudDeveloper/gaussdb-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestPgbouncerStatementCacheDescribe(t *testing.T) {
-	connString := os.Getenv(gaussdbgo.EnvGaussdbTestPgbouncerConnString)
-	if connString == "" {
-		t.Skipf("Skipping due to missing environment variable %v", gaussdbgo.EnvGaussdbTestPgbouncerConnString)
-	}
-
-	config := mustParseConfig(t, connString)
-	config.DefaultQueryExecMode = gaussdbgo.QueryExecModeCacheDescribe
-	config.DescriptionCacheCapacity = 1024
-
-	testPgbouncer(t, config, 10, 100)
-}
-
-func TestPgbouncerSimpleProtocol(t *testing.T) {
-	connString := os.Getenv(gaussdbgo.EnvGaussdbTestPgbouncerConnString)
-	if connString == "" {
-		t.Skipf("Skipping due to missing environment variable %v", gaussdbgo.EnvGaussdbTestPgbouncerConnString)
-	}
-
-	config := mustParseConfig(t, connString)
-	config.DefaultQueryExecMode = gaussdbgo.QueryExecModeSimpleProtocol
-
-	testPgbouncer(t, config, 10, 100)
-}
 
 func testPgbouncer(t *testing.T, config *gaussdbgo.ConnConfig, workers, iterations int) {
 	doneChan := make(chan struct{})


### PR DESCRIPTION
pgbouncer 是一款专为 PostgreSQL 设计的轻量级数据库连接池工具，主要用于优化数据库连接的复用和管理，降低高并发场景下的资源消耗。

在设置 password_encryption_type 为 0的时候, pgbouncer也无法连接GaussDB


![图片](https://github.com/user-attachments/assets/bd58141c-c9e9-4870-93cb-6de56242afc9)


![图片](https://github.com/user-attachments/assets/a883b4ef-501a-4ada-949a-ff07a33af15e)


在相同的password_encryption_type 配置情况下,opengauss是可以的
